### PR TITLE
Add authentication UI

### DIFF
--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/LoginScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/LoginScreen.kt
@@ -1,0 +1,259 @@
+package com.arygm.quickfix.ui.authentication
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+@Preview
+fun LogInScreen(LoD: Boolean = true) {
+
+    val color1 = if (LoD) Color(0xFFF16138) else Color(0xFF633040)
+    val color2 = if (LoD) Color(0xFF731734) else Color(0xFFB78080)
+    val backgroundColor = if (LoD) Color.White else Color(0xFF282828)
+    val errorColor = if (LoD) Color(0xFFFF5353) else Color(0xFFC54646)
+    var errorHasOccured by remember { mutableStateOf(false) }
+
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    val filledForm = email.isNotEmpty() && password.isNotEmpty()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .size(180.dp, 180.dp)
+                .offset(x = 115.dp, y = (-80).dp)
+                .graphicsLayer(rotationZ = 57f)
+                .background(color1)
+                .zIndex(1f)
+        )
+
+        Scaffold(
+            modifier = Modifier.background(backgroundColor),
+            topBar = {
+                TopAppBar(
+                    title = { Text("") },
+                    navigationIcon = {
+                        IconButton(
+                            //TODO: Button Logic When BackEnd Functions Are Done
+                            onClick = { },
+                            modifier = Modifier
+                                .testTag("goBackButton")
+                                .padding(start = 9.dp, top = 35.dp)
+                                .size(48.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                                contentDescription = "Back",
+                                tint = color1,
+                                modifier = Modifier.size(45.dp)
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = backgroundColor
+                    )
+                )
+            },
+            content = { pd ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(backgroundColor)
+                        .padding(pd)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .size(180.dp, 180.dp)
+                            .offset(x = (-150).dp, y = 64.dp)
+                            .graphicsLayer(rotationZ = 57f)
+                            .background(color1)
+                            .zIndex(0f)
+                    )
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(start = 24.dp),
+                        horizontalAlignment = Alignment.Start,
+                        verticalArrangement = Arrangement.Top
+                    ) {
+                        Spacer(modifier = Modifier.padding(100.dp))
+
+                        Text(
+                            "WELCOME BACK",
+                            fontSize = 32.sp,
+                            color = color1,
+                            fontWeight = FontWeight.ExtraBold,
+                            fontStyle = FontStyle.Italic
+                        )
+
+                        Spacer(modifier = Modifier.padding(6.dp))
+
+                        OutlinedTextField(
+                            value = email,
+                            onValueChange = { email = it },
+                            label = {
+                                Text(
+                                    "E-MAIL ADDRESS",
+                                    color = (if (errorHasOccured) errorColor else color2).copy(alpha = 0.6f),
+                                    fontWeight = FontWeight.ExtraBold,
+                                    fontSize = 20.sp,
+                                    fontStyle = FontStyle.Italic
+                                )
+                            },
+                            textStyle = androidx.compose.ui.text.TextStyle(
+                                color = color2.copy(alpha = 1f),  // Full opacity
+                                fontWeight = FontWeight.ExtraBold,
+                                fontSize = 20.sp,
+                                fontStyle = FontStyle.Italic
+                            ),
+                            singleLine = true,
+                            shape = RoundedCornerShape(10.dp),
+                            modifier = Modifier.width(360.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = color1,
+                                unfocusedBorderColor = color1,
+                                cursorColor = color1
+                            )
+                        )
+
+                        Spacer(modifier = Modifier.padding(3.dp))
+
+                        OutlinedTextField(
+                            value = password,
+                            onValueChange = { password = it },
+                            label = {
+                                Text(
+                                    "PASSWORD",
+                                    color = (if (errorHasOccured) errorColor else color2).copy(alpha = 0.6f),
+                                    fontWeight = FontWeight.ExtraBold,
+                                    fontSize = 20.sp,
+                                    fontStyle = FontStyle.Italic
+                                )
+                            },
+                            visualTransformation = PasswordVisualTransformation(),  // Shows password as dots
+                            textStyle = androidx.compose.ui.text.TextStyle(
+                                color = color2.copy(alpha = 1f),  // Full opacity
+                                fontWeight = FontWeight.ExtraBold,
+                                fontSize = 20.sp,
+                                fontStyle = FontStyle.Italic
+                            ),
+                            singleLine = true,
+                            shape = RoundedCornerShape(10.dp),
+                            modifier = Modifier.width(360.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = color1,
+                                unfocusedBorderColor = color1,
+                                cursorColor = color1
+                            )
+                        )
+
+                        Spacer(modifier = Modifier.padding(3.dp))
+
+                        Row(modifier = Modifier.padding(start = 3.dp)) {
+                            Text(
+                                "FORGOT YOUR PASSWORD ? TRY",
+                                fontSize = 12.sp,
+                                fontStyle = FontStyle.Italic,
+                                fontWeight = FontWeight.ExtraBold,
+                                color = Color(0xFFC0C0C0)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                "THIS.",
+                                fontSize = 12.sp,
+                                color = color1,
+                                fontWeight = FontWeight.ExtraBold,
+                                textDecoration = TextDecoration.Underline
+                            )
+                        }
+
+                        if (errorHasOccured) {
+                            Text(
+                                "INVALID EMAIL OR PASSWORD, TRY AGAIN.",
+                                fontSize = 12.sp,
+                                fontStyle = FontStyle.Italic,
+                                fontWeight = FontWeight.ExtraBold,
+                                color = errorColor,
+                                modifier = Modifier.padding(start = 3.dp)
+                            )
+                            Spacer(modifier = Modifier.padding(18.2.dp))
+                        } else {
+                            Spacer(modifier = Modifier.padding(30.dp))
+                        }
+
+                        Button(
+                            //TODO: Button Logic When BackEnd Functions Are Done
+                            onClick = { errorHasOccured = !errorHasOccured },
+                            modifier = Modifier
+                                .width(360.dp)
+                                .height(48.dp),
+                            shape = RoundedCornerShape(10.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = color1
+                            ),
+                            enabled = filledForm
+                        ) {
+                            Text(
+                                "LOGIN",
+                                fontSize = 20.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontStyle = FontStyle.Italic,
+                                color = if (LoD) Color.White else Color(0xFFB78080)
+                            )
+                        }
+                    }
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/PasswordScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/PasswordScreen.kt
@@ -1,0 +1,277 @@
+package com.arygm.quickfix.ui.authentication
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+@Preview
+fun PasswordScreen(LoD: Boolean = true) {
+    val color1 = if (LoD) Color(0xFFF16138) else Color(0xFF633040)
+    val color2 = if (LoD) Color(0xFF731734) else Color(0xFFB78080)
+    val backgroundColor = if (LoD) Color.White else Color(0xFF282828)
+    val errorColor = if (LoD) Color(0xFFFF5353) else Color(0xFFC54646)
+    val defaultTextColor = Color(0xFFC0C0C0)
+
+    var password by remember { mutableStateOf("") }
+    var repeatPassword by remember { mutableStateOf("") }
+
+    val noMatch by remember {
+        derivedStateOf { password != repeatPassword && repeatPassword.isNotEmpty() }
+    }
+
+    val passwordConditions = listOf(
+        "PASSWORD SHOULD BE AT LEAST 8 CHARACTERS" to (password.length >= 8),
+        "PASSWORD SHOULD CONTAIN AN UPPERCASE LETTER (A-Z)" to password.any { it.isUpperCase() },
+        "PASSWORD SHOULD CONTAIN A LOWERCASE LETTER (a-z)" to password.any { it.isLowerCase() },
+        "PASSWORD SHOULD CONTAIN A DIGIT (0-9)" to password.any { it.isDigit() }
+    )
+
+    val buttonActive = passwordConditions.all { it.second } && !noMatch
+
+    Box(modifier = Modifier.fillMaxSize()) {
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .size(180.dp, 180.dp)
+                .offset(x = 115.dp, y = (-80).dp)
+                .graphicsLayer(rotationZ = 57f)
+                .background(color1)
+                .zIndex(1f)
+        )
+
+        Scaffold(
+            modifier = Modifier.background(backgroundColor),
+            topBar = {
+                TopAppBar(
+                    title = { Text("") },
+                    navigationIcon = {
+                        IconButton(
+                            onClick = { /* TODO: Add navigation logic */ },
+                            modifier = Modifier
+                                .testTag("goBackButton")
+                                .padding(start = 9.dp, top = 35.dp)
+                                .size(48.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                                contentDescription = "Back",
+                                tint = color1,
+                                modifier = Modifier.size(45.dp)
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = backgroundColor
+                    )
+                )
+            },
+            content = { pd ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(backgroundColor)
+                        .padding(pd)
+                        .imePadding()  // Adjust layout when keyboard is shown
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .size(180.dp, 180.dp)
+                            .offset(x = (-150).dp, y = 64.dp)
+                            .graphicsLayer(rotationZ = 57f)
+                            .background(color1)
+                            .zIndex(0f)
+                    )
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(start = 24.dp)
+                            .verticalScroll(rememberScrollState()),  // Enable vertical scrolling
+                        horizontalAlignment = Alignment.Start,
+                        verticalArrangement = Arrangement.Top
+                    ) {
+                        Spacer(modifier = Modifier.padding(60.dp))  // Adjusted padding for top spacing
+
+                        Text(
+                            "ENTER YOUR\nPASSWORD",
+                            fontSize = 32.sp,
+                            color = color1,
+                            fontWeight = FontWeight.ExtraBold,
+                            fontStyle = FontStyle.Italic,
+                            lineHeight = 40.sp
+                        )
+
+                        Spacer(modifier = Modifier.padding(6.dp))
+
+                        // Password Field
+                        OutlinedTextField(
+                            value = password,
+                            onValueChange = { password = it },
+                            label = {
+                                Text(
+                                    "PASSWORD",
+                                    color = color2.copy(alpha = 0.6f),
+                                    fontWeight = FontWeight.ExtraBold,
+                                    fontSize = 20.sp,
+                                    fontStyle = FontStyle.Italic
+                                )
+                            },
+                            visualTransformation = PasswordVisualTransformation(),  // Shows password as dots
+                            textStyle = androidx.compose.ui.text.TextStyle(
+                                color = color2.copy(alpha = 1f),  // Full opacity
+                                fontWeight = FontWeight.ExtraBold,
+                                fontSize = 20.sp,
+                                fontStyle = FontStyle.Italic
+                            ),
+                            singleLine = true,
+                            shape = RoundedCornerShape(10.dp),
+                            modifier = Modifier.width(360.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = color1,
+                                unfocusedBorderColor = color1,
+                                cursorColor = color1
+                            ),
+                            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next)
+                        )
+
+                        Spacer(modifier = Modifier.padding(3.dp))
+
+                        // Repeat Password Field
+                        OutlinedTextField(
+                            value = repeatPassword,
+                            onValueChange = { repeatPassword = it },
+                            label = {
+                                Text(
+                                    "REPEAT PASSWORD",
+                                    color = color2.copy(alpha = 0.6f),
+                                    fontWeight = FontWeight.ExtraBold,
+                                    fontSize = 20.sp,
+                                    fontStyle = FontStyle.Italic,
+                                )
+                            },
+                            visualTransformation = PasswordVisualTransformation(),  // Shows password as dots
+                            textStyle = androidx.compose.ui.text.TextStyle(
+                                color = color2.copy(alpha = 1f),  // Full opacity
+                                fontWeight = FontWeight.ExtraBold,
+                                fontSize = 20.sp,
+                                fontStyle = FontStyle.Italic
+                            ),
+                            singleLine = true,
+                            shape = RoundedCornerShape(10.dp),
+                            modifier = Modifier.width(360.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = color1,
+                                unfocusedBorderColor = color1,
+                                cursorColor = color1
+                            ),
+                            keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done)
+                        )
+
+                        Spacer(modifier = Modifier.padding(3.dp))
+
+                        // Password Requirements List
+                        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+                            passwordConditions.forEach { (condition, met) ->
+                                Text(
+                                    text = condition,
+                                    color = if (met) defaultTextColor else errorColor,
+                                    fontSize = 12.sp,
+                                    fontStyle = FontStyle.Italic,
+                                    fontWeight = FontWeight.ExtraBold,
+                                    modifier = Modifier.padding(start = 3.dp)
+                                )
+                            }
+                        }
+
+                        // Error message if passwords don't match
+                        if (noMatch) {
+                            Text(
+                                "PASSWORDS DO NOT MATCH.",
+                                fontSize = 12.sp,
+                                fontStyle = FontStyle.Italic,
+                                fontWeight = FontWeight.ExtraBold,
+                                color = errorColor,
+                                modifier = Modifier.padding(start = 3.dp)
+                            )
+                            Spacer(modifier = Modifier.padding(18.2.dp))
+                        } else {
+                            Spacer(modifier = Modifier.padding(30.dp))
+                        }
+
+                        Button(
+                            onClick = { /* TODO: Add button logic */ },
+                            modifier = Modifier
+                                .width(360.dp)
+                                .height(48.dp),
+                            shape = RoundedCornerShape(10.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = color1
+                            ),
+                            enabled = buttonActive
+                        ) {
+                            Text(
+                                "REGISTER",
+                                fontSize = 20.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontStyle = FontStyle.Italic,
+                                color = if (LoD) Color.White else Color(0xFFB78080)
+                            )
+                        }
+                    }
+                }
+            }
+        )
+    }
+}
+

--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/RegistrationScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/RegistrationScreen.kt
@@ -1,0 +1,425 @@
+package com.arygm.quickfix.ui.authentication
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import java.util.regex.Pattern
+
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+@Preview
+fun RegistrationScreen(LoD: Boolean = true) {
+    val color1 = if (LoD) Color(0xFFF16138) else Color(0xFF633040)
+    val color2 = if (LoD) Color(0xFF731734) else Color(0xFFB78080)
+    val backgroundColor = if (LoD) Color.White else Color(0xFF282828)
+    val errorColor = if (LoD) Color(0xFFFF5353) else Color(0xFFC54646)
+
+    var firstName by remember { mutableStateOf("") }
+    var lastName by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var birthDate by remember { mutableStateOf("") }
+
+    var emailError by remember { mutableStateOf(false) }
+    var birthDateError by remember { mutableStateOf(false) }
+
+    var acceptTerms by remember { mutableStateOf(false) }
+    var acceptPrivacyPolicy by remember { mutableStateOf(false) }
+
+    fun isValidEmail(email: String): Boolean {
+        val emailPattern = "[a-zA-Z0-9._-]+@[a-z]+\\.+[a-z]+"
+        return Pattern.matches(emailPattern, email)
+    }
+
+    val filledForm =
+        firstName.isNotEmpty() && lastName.isNotEmpty() && email.isNotEmpty() && birthDate.isNotEmpty()
+
+    fun isValidDate(date: String): Boolean {
+        // Simple check for DD/MM/YYYY format
+        val datePattern = "^([0-2][0-9]|(3)[0-1])/((0)[1-9]|(1)[0-2])/((19|20)\\d\\d)$"
+        return Pattern.matches(datePattern, date)
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .size(180.dp, 180.dp)
+                .offset(x = 115.dp, y = (-80).dp)
+                .graphicsLayer(rotationZ = 57f)
+                .background(color1)
+                .zIndex(1f)
+        )
+
+        Scaffold(
+            modifier = Modifier.background(backgroundColor),
+            topBar = {
+                TopAppBar(
+                    title = { Text("") },
+                    navigationIcon = {
+                        IconButton(
+                            onClick = { /* TODO: Add navigation logic */ },
+                            modifier = Modifier
+                                .testTag("goBackButton")
+                                .padding(start = 9.dp, top = 35.dp)
+                                .size(48.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                                contentDescription = "Back",
+                                tint = color1,
+                                modifier = Modifier.size(45.dp)
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = backgroundColor
+                    )
+                )
+            },
+            content = { pd ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(backgroundColor)
+                        .padding(pd)
+                        .imePadding()
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .size(180.dp, 180.dp)
+                            .offset(x = (-150).dp, y = 64.dp)
+                            .graphicsLayer(rotationZ = 57f)
+                            .background(color1)
+                            .zIndex(0f)
+                    )
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(start = 24.dp)
+                            .verticalScroll(rememberScrollState()),
+                        horizontalAlignment = Alignment.Start,
+                        verticalArrangement = Arrangement.Top
+                    ) {
+                        Spacer(modifier = Modifier.padding(60.dp))
+
+                        Text(
+                            "WELCOME",
+                            fontSize = 32.sp,
+                            color = color1,
+                            fontWeight = FontWeight.ExtraBold,
+                            fontStyle = FontStyle.Italic,
+                        )
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(end = 18.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween // This arranges them with space in between
+                        ) {
+                            OutlinedTextField(
+                                value = firstName,
+                                onValueChange = { firstName = it },
+                                label = {
+                                    Text(
+                                        "FIRST NAME",
+                                        color = color2.copy(alpha = 0.6f),
+                                        fontWeight = FontWeight.ExtraBold,
+                                        fontSize = 20.sp,
+                                        fontStyle = FontStyle.Italic
+                                    )
+                                },
+                                modifier = Modifier
+                                    .weight(1f) // This ensures both fields take up equal space
+                                    .padding(end = 8.dp),
+                                textStyle = androidx.compose.ui.text.TextStyle(
+                                    color = color2.copy(alpha = 1f),  // Full opacity
+                                    fontWeight = FontWeight.ExtraBold,
+                                    fontSize = 20.sp,
+                                    fontStyle = FontStyle.Italic
+                                ),
+                                singleLine = true,
+                                shape = RoundedCornerShape(10.dp),
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = color1,
+                                    unfocusedBorderColor = color1,
+                                    cursorColor = color1
+                                )
+                            )
+
+                            OutlinedTextField(
+                                value = lastName,
+                                onValueChange = { lastName = it },
+                                label = {
+                                    Text(
+                                        "LAST NAME",
+                                        color = color2.copy(alpha = 0.6f),
+                                        fontWeight = FontWeight.ExtraBold,
+                                        fontSize = 20.sp,
+                                        fontStyle = FontStyle.Italic
+                                    )
+                                },
+                                modifier = Modifier
+                                    .weight(1f) // This ensures both fields take up equal space
+                                    .padding(end = 8.dp),
+                                textStyle = androidx.compose.ui.text.TextStyle(
+                                    color = color2.copy(alpha = 1f),  // Full opacity
+                                    fontWeight = FontWeight.ExtraBold,
+                                    fontSize = 20.sp,
+                                    fontStyle = FontStyle.Italic
+                                ),
+                                singleLine = true,
+                                shape = RoundedCornerShape(10.dp),
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = color1,
+                                    unfocusedBorderColor = color1,
+                                    cursorColor = color1
+                                )
+
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.padding(6.dp))
+
+                        // Email Field
+                        OutlinedTextField(
+                            value = email,
+                            onValueChange = {
+                                email = it
+                                emailError = !isValidEmail(it)
+                            },
+                            label = {
+                                Text(
+                                    "E-MAIL ADDRESS",
+                                    color = color2.copy(alpha = 0.6f),
+                                    fontWeight = FontWeight.ExtraBold,
+                                    fontSize = 20.sp,
+                                    fontStyle = FontStyle.Italic
+                                )
+                            },
+                            isError = emailError,
+                            modifier = Modifier.width(360.dp),
+                            singleLine = true,
+                            textStyle = androidx.compose.ui.text.TextStyle(
+                                color = color2.copy(alpha = 1f),  // Full opacity
+                                fontWeight = FontWeight.ExtraBold,
+                                fontSize = 20.sp,
+                                fontStyle = FontStyle.Italic
+                            ),
+                            shape = RoundedCornerShape(10.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = color1,
+                                unfocusedBorderColor = color1,
+                                cursorColor = color1
+                            )
+                        )
+
+                        if (emailError) {
+                            Text(
+                                "INVALID E-MAIL",
+                                color = errorColor,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontStyle = FontStyle.Italic,
+                                fontSize = 12.sp,
+                                modifier = Modifier.padding(top = 4.dp, start = 3.dp)
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.padding(6.dp))
+
+                        // Birth Date Field
+                        OutlinedTextField(
+                            value = birthDate,
+                            onValueChange = {
+                                birthDate = it
+                                birthDateError = !isValidDate(it)
+                            },
+                            label = {
+                                Text(
+                                    "BIRTH DATE: DD/MM/YYYY",
+                                    color = color2.copy(alpha = 0.6f),
+                                    fontWeight = FontWeight.ExtraBold,
+                                    fontSize = 20.sp,
+                                    fontStyle = FontStyle.Italic
+                                )
+                            },
+                            isError = birthDateError,
+                            modifier = Modifier.width(360.dp),
+                            singleLine = true,
+                            textStyle = androidx.compose.ui.text.TextStyle(
+                                color = color2.copy(alpha = 1f),  // Full opacity
+                                fontWeight = FontWeight.ExtraBold,
+                                fontSize = 20.sp,
+                                fontStyle = FontStyle.Italic
+                            ),
+                            shape = RoundedCornerShape(10.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = color1,
+                                unfocusedBorderColor = color1,
+                                cursorColor = color1
+                            )
+                        )
+
+                        if (birthDateError) {
+                            Text(
+                                "INVALID DATE",
+                                color = errorColor,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontStyle = FontStyle.Italic,
+                                fontSize = 12.sp,
+                                modifier = Modifier.padding(top = 4.dp, start = 3.dp)
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.padding(10.dp))
+
+                        // Checkboxes for terms and privacy policy
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Checkbox(
+                                checked = acceptTerms,
+                                onCheckedChange = { acceptTerms = it },
+                                colors = CheckboxDefaults.colors(
+                                    checkedColor = color1,  // The color of the checkbox when checked
+                                    uncheckedColor = Color(0xFFc0c0c0),  // Lighter color when unchecked
+                                    checkmarkColor = Color.Transparent  // Removes the check icon
+                                ), // More rounded shape
+                                modifier = Modifier.size(24.dp),  // Adjust the size if needed
+                            )
+                            Spacer(modifier = Modifier.width(10.dp))
+                            Text(
+                                "I HAVE READ AND ACCEPT THE",
+                                fontSize = 12.sp,
+                                fontStyle = FontStyle.Italic,
+                                fontWeight = FontWeight.ExtraBold,
+                                color = Color(0xFFC0C0C0)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                "TERMS AND CONDITIONS.",
+                                fontSize = 12.sp,
+                                color = color1,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontStyle = FontStyle.Italic,
+                                textDecoration = TextDecoration.Underline
+                            )
+
+                        }
+
+                        Spacer(modifier = Modifier.padding(4.dp))
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Checkbox(
+                                checked = acceptPrivacyPolicy,
+                                onCheckedChange = { acceptPrivacyPolicy = it },
+                                colors = CheckboxDefaults.colors(
+                                    checkedColor = color1,  // The color of the checkbox when checked
+                                    uncheckedColor = Color(0xFFc0c0c0),  // Lighter color when unchecked
+                                    checkmarkColor = Color.Transparent  // Removes the check icon
+                                ), // More rounded shape
+                                modifier = Modifier.size(24.dp),  // Adjust the size if needed
+                            )
+                            Spacer(modifier = Modifier.width(10.dp))
+                            Text(
+                                "I ACCEPT THE",
+                                fontSize = 12.sp,
+                                fontStyle = FontStyle.Italic,
+                                fontWeight = FontWeight.ExtraBold,
+                                color = Color(0xFFC0C0C0)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                "PRIVACY POLICY",
+                                fontSize = 12.sp,
+                                color = color1,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontStyle = FontStyle.Italic,
+                                textDecoration = TextDecoration.Underline
+                            )
+
+                        }
+
+                        Spacer(modifier = Modifier.padding(10.dp))
+
+                        // Button
+                        Button(
+                            onClick = { /* TODO: Add button logic */ },
+                            modifier = Modifier
+                                .width(360.dp)
+                                .height(48.dp),
+                            shape = RoundedCornerShape(10.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = color1
+                            ),
+                            enabled = acceptTerms && acceptPrivacyPolicy && filledForm
+                        ) {
+                            Text(
+                                "NEXT",
+                                fontSize = 20.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontStyle = FontStyle.Italic,
+                                color = if (LoD) Color.White else Color(0xFFB78080)
+                            )
+                        }
+                    }
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/WelcomeScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/WelcomeScreen.kt
@@ -1,0 +1,197 @@
+package com.github.se.bootcamp.ui.authentication
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+@Preview
+fun WelcomeScreen(LoD: Boolean = true) {
+
+    val color1 = if (LoD) Color(0xFFF16138) else Color(0xFF633040)
+    val color2 = if (LoD) Color(0xFF731734) else Color(0xFFB78080)
+    val backgroundColor = if (LoD) Color.White else Color(0xFF282828)
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        Image(
+            painter = painterResource(id = com.arygm.quickfix.R.drawable.worker_image),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            alignment = Alignment.TopStart,
+            modifier = Modifier
+                .fillMaxSize()
+        )
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .size(1000.dp, 1000.dp)
+                .offset(x = (-164).dp, y = 43.dp)
+                .graphicsLayer(rotationZ = -30f)
+                .background(color1)
+        )
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .size(425.dp, 150.dp)
+                .background(color1)
+        )
+
+        if(LoD){
+            Image(
+                painter = painterResource(id = com.arygm.quickfix.R.drawable.light_quickfix_logo),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .offset(x = 0.dp, y = -30.dp)
+                    .size(width = 283.dp,height = 325.dp)
+                    .graphicsLayer(rotationZ = 4.57f)
+            )
+        }else{
+            Image(
+                painter = painterResource(id = com.arygm.quickfix.R.drawable.dark_quickfix_logo),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .offset(x = 0.dp, y = -30.dp)
+                    .size(width = 283.dp,height = 325.dp)
+                    .graphicsLayer(rotationZ = 4.57f)
+            )
+        }
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 420.dp) // Adjust this to fine-tune the position below the logo
+        ) {
+
+            Spacer(modifier = Modifier.padding(60.dp))
+            // QuickFix Text
+            Text(
+                text = "QuickFix",
+                fontSize = 64.sp,
+                fontWeight = FontWeight.ExtraBold,
+                fontStyle = FontStyle.Italic,
+                color = backgroundColor,
+                modifier = Modifier
+                    .padding(bottom = 24.dp) // Space between text and buttons
+            )
+
+            // Buttons
+            Button(
+                onClick = { /* TODO: Log In action */ },
+                colors = ButtonDefaults.buttonColors(containerColor = color2),
+                modifier = Modifier
+                    .fillMaxWidth(0.8f)
+                    .height(50.dp)
+                    .padding(bottom = 8.dp),
+                shape = RoundedCornerShape(10.dp)
+            ) {
+                Text(text = "LOG IN TO QUICKFIX",
+                    color = backgroundColor,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    fontStyle = FontStyle.Italic)
+            }
+
+            Button(
+                onClick = { /* TODO: Register action */ },
+                colors = ButtonDefaults.buttonColors(containerColor = backgroundColor),
+                modifier = Modifier
+                    .fillMaxWidth(0.8f)
+                    .height(50.dp)
+                    .padding(bottom = 8.dp),
+                shape = RoundedCornerShape(10.dp)
+            ) {
+                Text(text = "REGISTER TO QUICKFIX",
+                    color = color2,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    fontStyle = FontStyle.Italic)
+            }
+
+            Button(
+                onClick = { /* TODO: Google action */ },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
+                border = BorderStroke(2.dp, backgroundColor),
+                modifier = Modifier
+                    .fillMaxWidth(0.8f)
+                    .height(50.dp),
+                shape = RoundedCornerShape(10.dp)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Start,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 0.dp)
+                ) {
+                    if(LoD){
+                        Image(
+                            painter = painterResource(id = com.arygm.quickfix.R.drawable.light_google_logo),
+                            contentDescription = "Google Logo",
+                            modifier = Modifier
+                                .size(20.dp)
+                                .offset(x = (-3).dp)
+                        )
+                    }else{
+                        Image(
+                            painter = painterResource(id = com.arygm.quickfix.R.drawable.dark_google_logo),
+                            contentDescription = "Google Logo",
+                            modifier = Modifier
+                                .size(20.dp)
+                                .offset(x = (-3).dp)
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.width(16.dp))
+
+                    // Button Text
+                    Text(
+                        text = "CONTINUE WITH GOOGLE",
+                        color = backgroundColor,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.ExtraBold,
+                        fontStyle = FontStyle.Italic
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added :

- Welcome screen with programmable buttons (login, sign in, and google login)
- A login screen that a user that chooses not to log in with google will see
- A register screen that a user that chooses to register with our own account database will see
- A password setting screen 

All buttons in those screens are intentionally left functionless for the backend team to complete (@JitterKiller @ramshty @Autek)

commit by: Mehdi (@AnotherMedo) and Georges (@Sebbayra) 