### PR TITLE
chore: add Mockito and Mockk libraries for unit and UI testing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -153,6 +153,9 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.mockk)
+    androidTestImplementation(libs.mockk.android)
+    androidTestImplementation(libs.mockk.agent)
     globalTestImplementation(libs.androidx.espresso.core)
 
     // ------------- Jetpack Compose ------------------
@@ -202,6 +205,12 @@ dependencies {
     androidTestImplementation(libs.cucumber.junit)
     androidTestImplementation(libs.cucumber.java)
     androidTestImplementation(libs.cucumber.android)
+
+    // ----------       Mockito         ------------
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.inline)
+    testImplementation(libs.mockito.kotlin)
+    androidTestImplementation(libs.mockito.android)
 }
 
 tasks.withType<Test> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,13 @@ mapsComposeUtils = "4.3.0"
 navigationCommonKtx = "2.8.2"
 navigationRuntimeKtx = "2.8.2"
 navigationCompose = "2.8.2"
+mockitoAndroid = "5.13.0"
+mockitoCore = "3.12.4"
+mockitoInline = "3.12.4"
+mockitoKotlin = "5.4.0"
+mockk = "1.13.7"
+mockkAgent = "1.13.7"
+mockkAndroid = "1.13.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -72,6 +79,14 @@ maps-compose-utils = { module = "com.google.maps.android:maps-compose-utils", ve
 androidx-navigation-common-ktx = { group = "androidx.navigation", name = "navigation-common-ktx", version.ref = "navigationCommonKtx" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockitoAndroid" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin" , version.ref="mockitoKotlin"}
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockkAgent" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockkAndroid" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Added Mockito core, inline, and Android libraries for unit testing.
- Added Mockk core, agent, and Android libraries for unit and UI testing.
- Updated `libs.versions.toml` with versions for Mockito and Mockk.
- Updated `build.gradle.kts` to include Mockito and Mockk dependencies for testing.