### PR TITLE
fix: add default web client ID to resolve FirebaseException

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">QuickFix</string>
     <string name="title_activity_main">MainActivity</string>
     <string name="title_activity_second">SecondActivity</string>
+    <string name="default_web_client_id">474287435896-7dj2qgfcu02g1bpesctlrtv22i69s23p.apps.googleusercontent.com</string>
 </resources>


### PR DESCRIPTION
- Added `default_web_client_id` string resource to `strings.xml` to fix the FirebaseException blocking requests from the Android client application.