### PR TITLE
ci: update SonarCloud command to include additional checks and reports

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -145,4 +145,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build sonar --info
+        run: ./gradlew build check connectedCheck jacocoTestReport sonar --info


### PR DESCRIPTION
- Changed the SonarCloud command in `.github/workflows/CI.yaml` from `./gradlew build sonar` to `./gradlew build check connectedCheck jacocoTestReport sonar`.
- This ensures that all checks and reports are generated before running the SonarCloud analysis.