### PR TITLE
ci: add GitHub Actions workflow for building APK

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -1,0 +1,68 @@
+name: Build APK
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+      KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+      KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+      GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+      LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v2
+        with:
+          api-level: 31
+          build-tools: 31.0.0
+          ndk: "21.1.6352462"
+
+      - name: Decode Keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > signIn.jks
+
+      - name: Decode secrets
+        run: |
+          echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
+
+      - name: Grant execute permission for gradlew
+        run: |
+          chmod +x ./gradlew
+
+      - name: Clean Gradle
+        run: ./gradlew clean
+
+      - name: Build with Gradle
+        run: ./gradlew assembleRelease
+
+#      - name: Sign the APK
+#        run: |
+#          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 -keystore signIn.jks -storepass $KEYSTORE_PASSWORD -keypass $KEY_PASSWORD app/build/outputs/apk/release/app-release.apk $KEY_ALIAS
+#
+#      - name: Zipalign the APK
+#        run: |
+#          $ANDROID_HOME/build-tools/31.0.0/zipalign -v 4 app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/app-M1.apk
+
+      - name: Upload APK as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release.apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,15 @@ android {
         manifestPlaceholders["SONAR_TOKEN"] = sonarToken
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = rootProject.file("signIn.jks")
+            storePassword = System.getenv("KEYSTORE_PASSWORD") ?: localProperties.getProperty("KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("KEY_ALIAS") ?: localProperties.getProperty("KEY_ALIAS")
+            keyPassword = System.getenv("KEY_PASSWORD") ?: localProperties.getProperty("KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -47,6 +56,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("release")
         }
 
         debug {


### PR DESCRIPTION
- Added `android.yaml` to configure GitHub Actions for building the APK.
- Included steps for signing and aligning the APK.
- Configured artifact upload for the release APK.