### PR TITLE
ci: add task to run `connectedCheck` with Firebase emulators and upda…

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -104,7 +104,7 @@ jobs:
             # Verify Firebase CLI installation
             firebase --version
 
-            firebase emulators:exec --debug --inspect-functions --project quickfix-1fd34  --import=./end2end-data --only firestore,auth './gradlew connectedCheck --parallel --build-cache'
+            ./gradlew connectedCheckWithEmulators --parallel --build-cache
 
       - name: Upload Failing Test Report Log
         if: failure()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradle.internal.classpath.Instrumented.systemProperty
 import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
 import java.util.Properties
@@ -16,6 +15,7 @@ android {
     buildFeatures {
         buildConfig = true
         compose = true
+        //noinspection DataBindingWithoutKapt
         dataBinding = true
     }
     namespace = "com.arygm.quickfix"
@@ -52,7 +52,6 @@ android {
             storePassword = System.getenv("KEYSTORE_PASSWORD") ?: localProperties.getProperty("KEYSTORE_PASSWORD")
             keyAlias = System.getenv("KEY_ALIAS") ?: localProperties.getProperty("KEY_ALIAS")
             keyPassword = System.getenv("KEY_PASSWORD") ?: localProperties.getProperty("KEY_PASSWORD")
-            storeType = "PKCS12" // Add this line if your keystore is PKCS12
         }
     }
 
@@ -66,15 +65,11 @@ android {
                 "proguard-rules.pro"
             )
             signingConfig = signingConfigs.getByName("release")
-            buildConfigField("boolean", "IS_TESTING", "false")
-            buildConfigField("String", "BUILD_TYPE", "\"DEBUG\"")
         }
 
         debug {
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
-            buildConfigField("boolean", "IS_TESTING", "true")
-            buildConfigField("String", "BUILD_TYPE", "\"RELEASE\"")
         }
     }
 
@@ -279,4 +274,21 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
     })
+}
+
+tasks.register("connectedCheckWithEmulators") {
+    doLast {
+        exec {
+            // Set the working directory to the root project directory
+            workingDir = rootProject.projectDir
+
+            // Run Firebase emulators and connectedCheck in a single command
+            commandLine = listOf(
+                "/bin/sh", "-c",
+                "firebase emulators:exec --debug --inspect-functions --project quickfix-1fd34 --import=./end2end-data --only firestore,auth './gradlew connectedCheck'"
+            )
+            standardOutput = System.out
+            errorOutput = System.err
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.6.1"
+agp = "8.7.2"
 databindingRuntime = "8.7.0"
 kotlin = "1.9.25"
 coreKtx = "1.13.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 11 13:43:48 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Summary
This PR introduces a new Gradle task and updates the CI workflow to enhance the testing process by running `connectedCheck` with Firebase emulators.

#### Changes
- **Gradle Build Script**:
  - Added a new task `connectedCheckWithEmulators` in `build.gradle.kts`.
  - This task sets the working directory to the root project directory.
  - Executes Firebase emulators and `connectedCheck` in a single command.

- **CI Workflow**:
  - Updated the CI workflow to use the new `connectedCheckWithEmulators` task.
  - Ensures Firebase CLI is installed and verified in CI.

#### Instructions for Developers
- **Firebase CLI Installation**:
  - Install Firebase CLI using either `brew` or `npm`:
    - **Homebrew**: `brew install firebase-cli`
    - **npm**: `npm install -g firebase-tools`
- **Running Tests**:
  - Use the new task `connectedCheckWithEmulators` instead of `connectedCheck` to run tests with Firebase emulators.

#### Impact
These changes will improve the reliability and coverage of our tests by leveraging Firebase emulators, ensuring a more robust testing environment.