### PR TITLE
feat: add worker profile filtering and unit tests

### DIFF
--- a/app/src/main/java/com/arygm/quickfix/model/profile/searchViewModel.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/profile/searchViewModel.kt
@@ -1,8 +1,15 @@
 package com.arygm.quickfix.model.profile
 
-/*
+import androidx.lifecycle.ViewModel
+import com.arygm.quickfix.model.Location.Location
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
-class WorkerListViewModel(private val repository: ProfileRepositoryFirestore) : ViewModel() {
+class searchViewModel(private val repository: WorkerProfileRepositoryFirestore) : ViewModel() {
 
   private val _workerProfiles = MutableStateFlow<List<Profile>>(emptyList())
   val workerProfiles: StateFlow<List<Profile>> = _workerProfiles
@@ -13,19 +20,25 @@ class WorkerListViewModel(private val repository: ProfileRepositoryFirestore) : 
   fun filterWorkerProfiles(
       hourlyRateThreshold: Double? = null,
       fieldOfWork: String? = null,
-      userLat: Double? = null,
-      userLon: Double? = null,
+      location: Location? = null,
       maxDistanceInKm: Double? = null
   ) {
+    val userLat = location?.latitude
+    val userLon = location?.longitude
+
     repository.filterWorkers(
         hourlyRateThreshold,
         fieldOfWork,
+        location,
+        maxDistanceInKm,
         { profiles ->
           if (userLat != null && userLon != null && maxDistanceInKm != null) {
             val filteredProfiles =
                 profiles.filter { profile ->
-                  val workerLat = profile.location?.latitude ?: return@filter false
-                  val workerLon = profile.location.longitude
+                  val location =
+                      profile.location ?: return@filter false // Ensure location is non-null
+                  val workerLat = location.latitude
+                  val workerLon = location.longitude
                   val distance = calculateDistance(userLat, userLon, workerLat, workerLon)
                   distance <= maxDistanceInKm
                 }
@@ -50,5 +63,3 @@ class WorkerListViewModel(private val repository: ProfileRepositoryFirestore) : 
     return earthRadius * c
   }
 }
-
- */

--- a/app/src/test/java/com/arygm/quickfix/model/profile/SearchViewModelTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/profile/SearchViewModelTest.kt
@@ -1,0 +1,199 @@
+package com.arygm.quickfix.model.profile
+
+import com.arygm.quickfix.model.Location.Location
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.ArgumentMatchers.isNull
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.anyOrNull
+
+class SearchViewModelTest {
+  private lateinit var viewModel: searchViewModel
+  private lateinit var mockRepository: WorkerProfileRepositoryFirestore
+
+  @Before
+  fun setUp() {
+    // Mock the repository
+    mockRepository = mock(WorkerProfileRepositoryFirestore::class.java)
+    // Initialize the ViewModel with the mocked repository
+    viewModel = searchViewModel(mockRepository)
+  }
+
+  @Test
+  fun testFilterWorkerProfilesByHourlyRateSuccess() {
+    // Arrange: Prepare expected worker profile and mock repository success behavior
+    val expectedProfiles =
+        listOf(
+            WorkerProfile(
+                uid = "worker_123",
+                hourlyRate = 25.0,
+                fieldOfWork = "Plumber",
+                location = Location(46.0, 6.0, "Test Location")))
+
+    // Mock repository behavior for a successful response
+    doAnswer { invocation ->
+          val onSuccess = invocation.arguments[4] as (List<WorkerProfile>) -> Unit
+          onSuccess(expectedProfiles) // Simulate success callback
+          null
+        }
+        .`when`(mockRepository)
+        .filterWorkers(eq(30.0), isNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+
+    // Act: Call ViewModel's function to filter worker profiles
+    viewModel.filterWorkerProfiles(hourlyRateThreshold = 30.0)
+
+    // Assert: Check that the ViewModel state is updated correctly
+    assertEquals(expectedProfiles, viewModel.workerProfiles.value)
+    assertNull(viewModel.errorMessage.value) // Ensure there's no error message
+  }
+
+  @Test
+  fun testFilterWorkerProfilesByHourlyRateFailure() {
+    // Arrange: Mock an error message and simulate repository failure behavior
+    val errorMessage = "Failed to fetch profiles"
+
+    // Mock repository behavior for a failure response
+    doAnswer { invocation ->
+          val onFailure = invocation.arguments[5] as (Exception) -> Unit
+          onFailure(Exception(errorMessage)) // Simulate failure callback
+          null
+        }
+        .`when`(mockRepository)
+        .filterWorkers(eq(30.0), isNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+
+    // Act: Call ViewModel's function to filter worker profiles
+    viewModel.filterWorkerProfiles(hourlyRateThreshold = 30.0)
+
+    // Assert: Check that the ViewModel state is updated correctly on failure
+    assertTrue(viewModel.workerProfiles.value.isEmpty()) // The list should be empty
+    assertEquals(errorMessage, viewModel.errorMessage.value) // Ensure error message is set
+  }
+
+  @Test
+  fun testFilterWorkerProfilesByFieldOfWorkSuccess() {
+    // Arrange: Prepare expected worker profiles and mock repository success behavior
+    val expectedProfiles =
+        listOf(
+            WorkerProfile(
+                uid = "worker_124",
+                hourlyRate = 40.0,
+                fieldOfWork = "Electrician",
+                location = Location(46.0, 7.0, "Another Test Location")))
+
+    // Mock repository behavior for a successful response
+    doAnswer { invocation ->
+          val onSuccess = invocation.arguments[4] as (List<WorkerProfile>) -> Unit
+          onSuccess(expectedProfiles) // Simulate success callback
+          null
+        }
+        .`when`(mockRepository)
+        .filterWorkers(
+            isNull(), eq("Electrician"), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+
+    // Act: Call ViewModel's function to filter worker profiles by field of work
+    viewModel.filterWorkerProfiles(fieldOfWork = "Electrician")
+
+    // Assert: Check that the ViewModel state is updated correctly
+    assertEquals(expectedProfiles, viewModel.workerProfiles.value)
+    assertNull(viewModel.errorMessage.value)
+  }
+
+  @Test
+  fun testFilterWorkerProfilesByDistanceSuccess() {
+    // Arrange: Prepare expected worker profiles
+    val profiles =
+        listOf(
+            WorkerProfile(
+                uid = "worker_125",
+                hourlyRate = 30.0,
+                fieldOfWork = "Handyman",
+                location = Location(46.5, 6.6, "Nearby Location")))
+
+    // Mock repository behavior
+    doAnswer { invocation ->
+          val onSuccess = invocation.arguments[4] as (List<WorkerProfile>) -> Unit
+          onSuccess(profiles) // Simulate success callback
+          null
+        }
+        .`when`(mockRepository)
+        .filterWorkers(isNull(), isNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+
+    // Act: Filter profiles by distance (user's location vs worker's location)
+    viewModel.filterWorkerProfiles(
+        location = Location(46.0, 6.0, "User Location"), maxDistanceInKm = 100.0)
+
+    // Assert: Ensure the profiles list contains the correct workers within the distance
+    val result = viewModel.workerProfiles.value
+    assertEquals(1, result.size)
+    assertEquals("worker_125", result[0].uid)
+  }
+
+  @Test
+  fun testFilterWorkerProfilesWithAllNullParameters() {
+    // Arrange: Prepare worker profiles
+    val profiles =
+        listOf(
+            WorkerProfile(
+                uid = "worker_126",
+                hourlyRate = 20.0,
+                fieldOfWork = "Gardening",
+                location = Location(45.5, 6.0, "Far Away Location")))
+
+    // Mock repository behavior for a successful response
+    doAnswer { invocation ->
+          val onSuccess = invocation.arguments[4] as (List<WorkerProfile>) -> Unit
+          onSuccess(profiles) // Simulate success callback
+          null
+        }
+        .`when`(mockRepository)
+        .filterWorkers(isNull(), isNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+
+    // Act: Call ViewModel's function with all null parameters
+    viewModel.filterWorkerProfiles()
+
+    // Assert: Check that all profiles are returned without any filtering
+    assertEquals(profiles, viewModel.workerProfiles.value)
+  }
+
+  @Test
+  fun testFilterWorkerProfilesWithMultipleFilters() {
+    // Arrange: Prepare worker profiles
+    val profiles =
+        listOf(
+            WorkerProfile(
+                uid = "worker_127",
+                hourlyRate = 45.0,
+                fieldOfWork = "Journalist",
+                location = Location(47.0, 8.0, "Metropolis")),
+            WorkerProfile(
+                uid = "worker_128",
+                hourlyRate = 80.0,
+                fieldOfWork = "CEO",
+                location = Location(40.0, -74.0, "Gotham City")))
+
+    // Mock repository behavior for a successful response
+    doAnswer { invocation ->
+          val onSuccess = invocation.arguments[4] as (List<WorkerProfile>) -> Unit
+          onSuccess(profiles) // Simulate success callback
+          null
+        }
+        .`when`(mockRepository)
+        .filterWorkers(eq(50.0), isNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+
+    // Act: Apply multiple filters
+    viewModel.filterWorkerProfiles(
+        hourlyRateThreshold = 50.0,
+        location = Location(46.0, 6.0, "User Location"),
+        maxDistanceInKm = 500.0)
+
+    // Assert: Only "worker_127" should match the filters
+    val result = viewModel.workerProfiles.value
+    assertEquals(1, result.size)
+    assertEquals("worker_127", result[0].uid)
+  }
+}


### PR DESCRIPTION
- Implemented filtering functionality in `WorkerProfileRepositoryFirestore` to support querying worker profiles based on:
  - `fieldOfWork`: filters by specified job field (e.g., Plumber, Electrician)
  - `hourlyRateThreshold`: filters profiles with hourly rates below a specified threshold
  - `location` and `radiusInKm`: filters profiles within a geographic radius based on latitude and longitude
- Designed robust unit tests for each filter criteria and combined criteria, covering success and failure scenarios
- Used mock Firestore queries to simulate chaining behavior and ensure accurate filtering across all conditions