### PR TITLE
fix: Fix the navigation where we inversed the logic

### DIFF
--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/WelcomeScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/WelcomeScreen.kt
@@ -82,11 +82,11 @@ fun WelcomeScreen(
       rememberFirebaseAuthLauncher(
           onAuthCompleteOne = { result ->
             Log.d("SignInScreen", "User signed in: ${result.user?.displayName}")
-            navigationActions.navigateTo(Screen.GOOGLE_INFO)
+            navigationActions.navigateTo(TopLevelDestinations.HOME)
           },
           onAuthCompleteTwo = { result ->
             Log.d("SignInScreen", "User signed in: ${result.user?.displayName}")
-            navigationActions.navigateTo(TopLevelDestinations.HOME)
+            navigationActions.navigateTo(Screen.GOOGLE_INFO)
           },
           onAuthError = { Log.e("SignInScreen", "Failed to sign in: ${it.statusCode}") },
           accountViewModel,


### PR DESCRIPTION
 Since I couldn't manually test because of emulator network error, i just checked really quick on another member's laptop so i missed this slight issue, won't be repeated.
 The issue was we were entering google info every time except the creation which should be the exact opposite.