### PR TITLE
Build Announcement Screen Based on Figma Design

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementScreenTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementScreenTest.kt
@@ -1,18 +1,19 @@
 package com.arygm.quickfix.ui.search
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import com.arygm.quickfix.ui.navigation.NavigationActions
-import com.arygm.quickfix.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 
 class AnnouncementScreenTest {
+
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var navigationActions: NavigationActions
@@ -20,30 +21,107 @@ class AnnouncementScreenTest {
   @Before
   fun setup() {
     navigationActions = mock(NavigationActions::class.java)
-
-    `when`(navigationActions.currentRoute()).thenReturn(Screen.SEARCH)
   }
 
   @Test
-  fun announcementScreenUserDisplaysCorrectly() {
-    composeTestRule.setContent { AnnouncementScreen(navigationActions, true) }
+  fun announcementScreenDisplaysCorrectly() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
 
-    composeTestRule.onNodeWithTag("AnnouncementContent").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("AnnouncementText").assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("AnnouncementText")
-        .assertTextContains("Welcome to the Announcement Screen")
+    // Check that each labeled component in the screen is displayed
+    composeTestRule.onNodeWithTag("titleInput").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("categoryInput").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("descriptionInput").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("locationInput").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("availabilityButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("picturesButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("announcementButton").assertIsDisplayed()
   }
 
-  // Can Remove this tbh
   @Test
-  fun announcementScreenWorkerDisplaysCorrectly() {
-    composeTestRule.setContent { AnnouncementScreen(navigationActions, false) }
+  fun textFieldDisplaysCorrectPlaceholdersAndLabels() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
 
-    composeTestRule.onNodeWithTag("AnnouncementContent").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("AnnouncementText").assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("AnnouncementText")
-        .assertTextContains("Welcome to the Announcement Screen")
+    // Check each placeholder text and labels in text fields
+    composeTestRule.onNodeWithTag("titleText").assertTextEquals("Title *")
+    composeTestRule.onNodeWithTag("categoryText").assertTextEquals("Category *")
+    composeTestRule.onNodeWithTag("descriptionText").assertTextEquals("Description *")
+    composeTestRule.onNodeWithTag("locationText").assertTextEquals("Location *")
+  }
+
+  @Test
+  fun titleInputAcceptsText() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
+
+    // Enter text in the title input and verify it
+    val titleText = "My QuickFix Title"
+    composeTestRule.onNodeWithTag("titleInput").performTextInput(titleText)
+    composeTestRule.onNodeWithTag("titleInput").assertTextEquals(titleText)
+  }
+
+  @Test
+  fun categoryInputAcceptsText() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
+
+    // Enter text in the category input and verify it
+    val categoryText = "ResidentialPainting"
+    composeTestRule.onNodeWithTag("categoryInput").performTextInput(categoryText)
+    composeTestRule.onNodeWithTag("categoryInput").assertTextEquals(categoryText)
+  }
+
+  @Test
+  fun descriptionInputAcceptsText() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
+
+    // Enter text in the description input and verify it
+    val descriptionText = "Detailed description"
+    composeTestRule.onNodeWithTag("descriptionInput").performTextInput(descriptionText)
+    composeTestRule.onNodeWithTag("descriptionInput").assertTextEquals(descriptionText)
+  }
+
+  @Test
+  fun locationInputAcceptsText() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
+
+    // Enter text in the location input and verify it
+    val locationText = "Lausanne Switzerland"
+    composeTestRule.onNodeWithTag("locationInput").performTextInput(locationText)
+    composeTestRule.onNodeWithTag("locationInput").assertTextEquals(locationText)
+  }
+
+  @Test
+  fun availabilityButtonClickable() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
+
+    // Perform click on the availability button and check if it's displayed
+    composeTestRule.onNodeWithTag("availabilityButton").performClick().assertIsDisplayed()
+  }
+
+  @Test
+  fun picturesButtonClickable() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
+
+    // Perform click on the pictures button and check if it's displayed
+    composeTestRule.onNodeWithTag("picturesButton").performClick().assertIsDisplayed()
+  }
+
+  @Test
+  fun mandatoryFieldsMessageDisplaysCorrectly() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
+
+    composeTestRule.onNodeWithTag("mandatoryText").assertTextEquals("* Mandatory fields")
+  }
+
+  @Test
+  fun announcementButtonEnabledWhenAllFieldsAreValid() {
+    composeTestRule.setContent { AnnouncementScreen(navigationActions) }
+
+    // Enter valid text in all fields to enable the announcement button
+    composeTestRule.onNodeWithTag("titleInput").performTextInput("QuickFix Title")
+    composeTestRule.onNodeWithTag("categoryInput").performTextInput("Home Repair")
+    composeTestRule.onNodeWithTag("descriptionInput").performTextInput("Detailed Description")
+    composeTestRule.onNodeWithTag("locationInput").performTextInput("New York City")
+
+    // Check if the "Post your announcement" button is enabled
+    composeTestRule.onNodeWithTag("announcementButton").assertIsDisplayed().performClick()
   }
 }

--- a/app/src/main/java/com/arygm/quickfix/MainActivity.kt
+++ b/app/src/main/java/com/arygm/quickfix/MainActivity.kt
@@ -162,15 +162,14 @@ fun QuickFixApp() {
                 }
               }
 
-              composable(Route.HOME) { HomeNavHost(innerPadding, isUser) }
+              composable(Route.HOME) { HomeNavHost(isUser) }
 
-              composable(Route.SEARCH) { SearchNavHost(innerPadding, isUser, navigationActions) }
+              composable(Route.SEARCH) { SearchNavHost(isUser, navigationActions) }
 
-              composable(Route.DASHBOARD) { DashBoardNavHost(innerPadding, isUser) }
+              composable(Route.DASHBOARD) { DashBoardNavHost(isUser) }
 
               composable(Route.PROFILE) {
                 ProfileNavHost(
-                    innerPadding,
                     accountViewModel,
                     loggedInAccountViewModel,
                     workerViewModel,
@@ -181,7 +180,7 @@ fun QuickFixApp() {
 }
 
 @Composable
-fun HomeNavHost(innerPadding: PaddingValues, isUser: Boolean) {
+fun HomeNavHost(isUser: Boolean) {
   val homeNavController = rememberNavController()
   val navigationActions = remember { NavigationActions(homeNavController) }
   NavHost(navController = homeNavController, startDestination = Screen.HOME) {
@@ -191,7 +190,6 @@ fun HomeNavHost(innerPadding: PaddingValues, isUser: Boolean) {
 
 @Composable
 fun ProfileNavHost(
-    innerPadding: PaddingValues,
     accountViewModel: AccountViewModel,
     loggedInAccountViewModel: LoggedInAccountViewModel,
     workerViewModel: ProfileViewModel,
@@ -216,7 +214,7 @@ fun ProfileNavHost(
 }
 
 @Composable
-fun DashBoardNavHost(innerPadding: PaddingValues, isUser: Boolean) {
+fun DashBoardNavHost(isUser: Boolean) {
   val dashboardNavController = rememberNavController()
   val navigationActions = remember { NavigationActions(dashboardNavController) }
   NavHost(navController = dashboardNavController, startDestination = Screen.DASHBOARD) {
@@ -226,7 +224,6 @@ fun DashBoardNavHost(innerPadding: PaddingValues, isUser: Boolean) {
 
 @Composable
 fun SearchNavHost(
-    innerPadding: PaddingValues,
     isUser: Boolean,
     navigationActionsRoot: NavigationActions
 ) {
@@ -235,7 +232,6 @@ fun SearchNavHost(
   NavHost(
       navController = searchNavController,
       startDestination = Screen.SEARCH,
-      modifier = Modifier.padding(innerPadding),
   ) {
     composable(Screen.SEARCH) {
       QuickFixFinderScreen(navigationActions, navigationActionsRoot, isUser)

--- a/app/src/main/java/com/arygm/quickfix/MainActivity.kt
+++ b/app/src/main/java/com/arygm/quickfix/MainActivity.kt
@@ -9,7 +9,6 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -170,10 +169,7 @@ fun QuickFixApp() {
 
               composable(Route.PROFILE) {
                 ProfileNavHost(
-                    accountViewModel,
-                    loggedInAccountViewModel,
-                    workerViewModel,
-                    navigationActions)
+                    accountViewModel, loggedInAccountViewModel, workerViewModel, navigationActions)
               }
             }
       }
@@ -223,10 +219,7 @@ fun DashBoardNavHost(isUser: Boolean) {
 }
 
 @Composable
-fun SearchNavHost(
-    isUser: Boolean,
-    navigationActionsRoot: NavigationActions
-) {
+fun SearchNavHost(isUser: Boolean, navigationActionsRoot: NavigationActions) {
   val searchNavController = rememberNavController()
   val navigationActions = remember { NavigationActions(searchNavController) }
   NavHost(

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixTextFieldCustom.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixTextFieldCustom.kt
@@ -80,124 +80,108 @@ fun QuickFixTextFieldCustom(
     label: @Composable (() -> Unit)? = {},
     onClick: Boolean = false
 ) {
-    val scrollState = rememberScrollState() // Scroll state for horizontal scrolling
-    // Launch a coroutine to scroll to the end of the text when typing
-    LaunchedEffect(TextFieldValue(value)) { scrollState.animateScrollTo(scrollState.maxValue) }
+  val scrollState = rememberScrollState() // Scroll state for horizontal scrolling
+  // Launch a coroutine to scroll to the end of the text when typing
+  LaunchedEffect(TextFieldValue(value)) { scrollState.animateScrollTo(scrollState.maxValue) }
 
-    if (showLabel) {
-        if (label != null) {
-            label()
-            Spacer(modifier = Modifier.padding(1.5.dp))
-        }
+  if (showLabel) {
+    if (label != null) {
+      label()
+      Spacer(modifier = Modifier.padding(1.5.dp))
     }
-    Box(
-        modifier =
-        Modifier
-            .let {
+  }
+  Box(
+      modifier =
+          Modifier.let {
                 if (isError)
-                    it
-                        .clip(shape)
+                    it.clip(shape)
                         .background(MaterialTheme.colorScheme.surface)
                         .border(1.dp, errorColor, shape)
                         .background(errorColor.copy(alpha = 0.2f))
                 else
-                    it
-                        .shadow(elevation = 2.dp, shape = shape, clip = false)
+                    it.shadow(elevation = 2.dp, shape = shape, clip = false)
                         .clip(shape)
                         .background(MaterialTheme.colorScheme.surface)
-            }
-            .size(width = widthField, height = heightField) // Set the width and height
-            .fillMaxWidth() // Fill the width of the container
-            .padding(start = moveContentHorizontal, top = moveContentTop, bottom = moveContentTop)
-            .clickable { onTextFieldClick() }
-            .testTag(C.Tag.main_container_text_field_custom), // Apply padding
-        contentAlignment = Alignment.Center) {
+              }
+              .size(width = widthField, height = heightField) // Set the width and height
+              .fillMaxWidth() // Fill the width of the container
+              .padding(start = moveContentHorizontal, top = moveContentTop, bottom = moveContentTop)
+              .clickable { onTextFieldClick() }
+              .testTag(C.Tag.main_container_text_field_custom), // Apply padding
+      contentAlignment = Alignment.Center) {
         Row(
             horizontalArrangement = Arrangement.Center, // Aligning icon and text horizontally
             verticalAlignment = Alignment.CenterVertically, // Aligning icon and text vertically
-            modifier = modifier.fillMaxWidth()
-        ) {
-            if (showLeadingIcon()) { // Conditionally show the leading icon
+            modifier = modifier.fillMaxWidth()) {
+              if (showLeadingIcon()) { // Conditionally show the leading icon
                 if (leadingIcon != null) {
-                    Icon(
-                        imageVector = leadingIcon,
-                        contentDescription = descriptionLeadIcon,
-                        tint = leadIconColor, // Icon color
-                        modifier =
-                        Modifier
-                            .size(sizeIconGroup) // Set icon size
-                            .padding(end = 8.dp)
-                            .testTag(C.Tag.icon_custom_text_field) // Space between icon and text
-                    )
+                  Icon(
+                      imageVector = leadingIcon,
+                      contentDescription = descriptionLeadIcon,
+                      tint = leadIconColor, // Icon color
+                      modifier =
+                          Modifier.size(sizeIconGroup) // Set icon size
+                              .padding(end = 8.dp)
+                              .testTag(C.Tag.icon_custom_text_field) // Space between icon and text
+                      )
                 }
-            }
-            Spacer(
-                modifier.padding(
-                    horizontal = spaceBetweenLeadIconText
-                )
-            ) // Space between icon and text
-            Box(modifier = Modifier.weight(1f)) {
+              }
+              Spacer(
+                  modifier.padding(
+                      horizontal = spaceBetweenLeadIconText)) // Space between icon and text
+              Box(modifier = Modifier.weight(1f)) {
                 BasicTextField(
                     value = value,
                     onValueChange = { onValueChange(it) },
                     modifier =
-                    modifier
-                        .fillMaxWidth()
-                        .focusRequester(focusRequester)
-                        .testTag(
-                            C.Tag.text_field_custom
-                        )
-                        .focusable(true)
-                        .let {
-                            if (singleLine) {
+                        modifier
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester)
+                            .testTag(C.Tag.text_field_custom)
+                            .focusable(true)
+                            .let {
+                              if (singleLine) {
                                 it.horizontalScroll(scrollState)
-                            } else it// Enable horizontal scrolling
-                        },
+                              } else it // Enable horizontal scrolling
+                            },
                     textStyle =
-                    textStyle.copy(
-                        color =
-                        if (isError) errorColor else textColor
-                    ), // Text style with color
+                        textStyle.copy(
+                            color =
+                                if (isError) errorColor else textColor), // Text style with color
                     singleLine = singleLine, // Keep the text on a single line
                     keyboardOptions = keyboardOptions,
                     visualTransformation = visualTransformation,
                 )
                 if (value.isEmpty()) {
-                    Text(
-                        modifier = Modifier.testTag(C.Tag.place_holder_text_field_custom),
-                        text = placeHolderText,
-                        style =
-                        textStyle.copy(
-                            color =
-                            if (isError) errorColor
-                            else placeHolderColor
-                        ) // Placeholder text style
-                    )
+                  Text(
+                      modifier = Modifier.testTag(C.Tag.place_holder_text_field_custom),
+                      text = placeHolderText,
+                      style =
+                          textStyle.copy(
+                              color =
+                                  if (isError) errorColor
+                                  else placeHolderColor) // Placeholder text style
+                      )
                 }
-            }
-            if (showTrailingIcon() && value.isNotEmpty()) {
+              }
+              if (showTrailingIcon() && value.isNotEmpty()) {
                 IconButton(
                     onClick = { if (onClick) onValueChange("") },
                     modifier =
-                    Modifier
-                        .testTag(C.Tag.clear_button_text_field_custom)
-                        .size(sizeIconGroup)
-                        .padding(end = 9.dp)
-                        .align(Alignment.CenterVertically)
-                ) {
-                    trailingIcon?.invoke()
-                }
+                        Modifier.testTag(C.Tag.clear_button_text_field_custom)
+                            .size(sizeIconGroup)
+                            .padding(end = 9.dp)
+                            .align(Alignment.CenterVertically)) {
+                      trailingIcon?.invoke()
+                    }
+              }
             }
-        }
-    }
-    if (showError && isError) {
-        Text(
-            errorText,
-            color = MaterialTheme.colorScheme.error,
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier
-                .padding(top = 4.dp, start = 3.dp)
-                .testTag("errorText")
-        )
-    }
+      }
+  if (showError && isError) {
+    Text(
+        errorText,
+        color = MaterialTheme.colorScheme.error,
+        style = MaterialTheme.typography.bodySmall,
+        modifier = Modifier.padding(top = 4.dp, start = 3.dp).testTag("errorText"))
+  }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixTextFieldCustom.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixTextFieldCustom.kt
@@ -22,8 +22,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -41,7 +39,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arygm.quickfix.ressources.C
 import com.arygm.quickfix.ui.theme.poppinsTypography
-import org.w3c.dom.Text
 
 @Composable
 fun QuickFixTextFieldCustom(
@@ -83,107 +80,124 @@ fun QuickFixTextFieldCustom(
     label: @Composable (() -> Unit)? = {},
     onClick: Boolean = false
 ) {
-  val scrollState = rememberScrollState() // Scroll state for horizontal scrolling
-  // Launch a coroutine to scroll to the end of the text when typing
-  LaunchedEffect(TextFieldValue(value)) { scrollState.animateScrollTo(scrollState.maxValue) }
+    val scrollState = rememberScrollState() // Scroll state for horizontal scrolling
+    // Launch a coroutine to scroll to the end of the text when typing
+    LaunchedEffect(TextFieldValue(value)) { scrollState.animateScrollTo(scrollState.maxValue) }
 
-  if (showLabel) {
-    if (label != null) {
-      label()
-      Spacer(modifier = Modifier.padding(1.5.dp))
+    if (showLabel) {
+        if (label != null) {
+            label()
+            Spacer(modifier = Modifier.padding(1.5.dp))
+        }
     }
-  }
-  Box(
-      modifier =
-          Modifier.let {
+    Box(
+        modifier =
+        Modifier
+            .let {
                 if (isError)
-                    it.clip(shape)
+                    it
+                        .clip(shape)
                         .background(MaterialTheme.colorScheme.surface)
                         .border(1.dp, errorColor, shape)
                         .background(errorColor.copy(alpha = 0.2f))
                 else
-                    it.shadow(elevation = 2.dp, shape = shape, clip = false)
+                    it
+                        .shadow(elevation = 2.dp, shape = shape, clip = false)
                         .clip(shape)
                         .background(MaterialTheme.colorScheme.surface)
-              }
-              .size(width = widthField, height = heightField) // Set the width and height
-              .fillMaxWidth() // Fill the width of the container
-              .padding(start = moveContentHorizontal, top = moveContentTop, bottom = moveContentTop)
-              .clickable { onTextFieldClick() }
-              .testTag(C.Tag.main_container_text_field_custom), // Apply padding
-      contentAlignment = Alignment.Center) {
+            }
+            .size(width = widthField, height = heightField) // Set the width and height
+            .fillMaxWidth() // Fill the width of the container
+            .padding(start = moveContentHorizontal, top = moveContentTop, bottom = moveContentTop)
+            .clickable { onTextFieldClick() }
+            .testTag(C.Tag.main_container_text_field_custom), // Apply padding
+        contentAlignment = Alignment.Center) {
         Row(
             horizontalArrangement = Arrangement.Center, // Aligning icon and text horizontally
             verticalAlignment = Alignment.CenterVertically, // Aligning icon and text vertically
-            modifier = modifier.fillMaxWidth()) {
-              if (showLeadingIcon()) { // Conditionally show the leading icon
+            modifier = modifier.fillMaxWidth()
+        ) {
+            if (showLeadingIcon()) { // Conditionally show the leading icon
                 if (leadingIcon != null) {
-                  Icon(
-                      imageVector = leadingIcon,
-                      contentDescription = descriptionLeadIcon,
-                      tint = leadIconColor, // Icon color
-                      modifier =
-                          Modifier.size(sizeIconGroup) // Set icon size
-                              .padding(end = 8.dp)
-                              .testTag(C.Tag.icon_custom_text_field) // Space between icon and text
-                      )
+                    Icon(
+                        imageVector = leadingIcon,
+                        contentDescription = descriptionLeadIcon,
+                        tint = leadIconColor, // Icon color
+                        modifier =
+                        Modifier
+                            .size(sizeIconGroup) // Set icon size
+                            .padding(end = 8.dp)
+                            .testTag(C.Tag.icon_custom_text_field) // Space between icon and text
+                    )
                 }
-              }
-              Spacer(
-                  modifier.padding(
-                      horizontal = spaceBetweenLeadIconText)) // Space between icon and text
-              Box(modifier = Modifier.weight(1f)) {
+            }
+            Spacer(
+                modifier.padding(
+                    horizontal = spaceBetweenLeadIconText
+                )
+            ) // Space between icon and text
+            Box(modifier = Modifier.weight(1f)) {
                 BasicTextField(
                     value = value,
                     onValueChange = { onValueChange(it) },
                     modifier =
-                        modifier
-                            .fillMaxWidth()
-                            .horizontalScroll(scrollState) // Enable horizontal scrolling
-                            .focusable(true)
-                            .focusRequester(focusRequester)
-                            .testTag(
-                                C.Tag.text_field_custom) // Makes the text field take up remaining
-                    // space
-                    ,
+                    modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester)
+                        .testTag(
+                            C.Tag.text_field_custom
+                        )
+                        .focusable(true)
+                        .let {
+                            if (singleLine) {
+                                it.horizontalScroll(scrollState)
+                            } else it// Enable horizontal scrolling
+                        },
                     textStyle =
-                        textStyle.copy(
-                            color =
-                                if (isError) errorColor else textColor), // Text style with color
+                    textStyle.copy(
+                        color =
+                        if (isError) errorColor else textColor
+                    ), // Text style with color
                     singleLine = singleLine, // Keep the text on a single line
                     keyboardOptions = keyboardOptions,
                     visualTransformation = visualTransformation,
                 )
                 if (value.isEmpty()) {
-                  Text(
-                      modifier = Modifier.testTag(C.Tag.place_holder_text_field_custom),
-                      text = placeHolderText,
-                      style =
-                          textStyle.copy(
-                              color =
-                                  if (isError) errorColor
-                                  else placeHolderColor) // Placeholder text style
-                      )
+                    Text(
+                        modifier = Modifier.testTag(C.Tag.place_holder_text_field_custom),
+                        text = placeHolderText,
+                        style =
+                        textStyle.copy(
+                            color =
+                            if (isError) errorColor
+                            else placeHolderColor
+                        ) // Placeholder text style
+                    )
                 }
-              }
-              if (showTrailingIcon() && value.isNotEmpty()) {
+            }
+            if (showTrailingIcon() && value.isNotEmpty()) {
                 IconButton(
                     onClick = { if (onClick) onValueChange("") },
                     modifier =
-                        Modifier.testTag(C.Tag.clear_button_text_field_custom)
-                            .size(sizeIconGroup)
-                            .padding(end = 9.dp)
-                            .align(Alignment.CenterVertically)) {
-                      trailingIcon?.invoke()
-                    }
-              }
+                    Modifier
+                        .testTag(C.Tag.clear_button_text_field_custom)
+                        .size(sizeIconGroup)
+                        .padding(end = 9.dp)
+                        .align(Alignment.CenterVertically)
+                ) {
+                    trailingIcon?.invoke()
+                }
             }
-      }
-  if (showError && isError) {
-    Text(
-        errorText,
-        color = MaterialTheme.colorScheme.error,
-        style = MaterialTheme.typography.bodySmall,
-        modifier = Modifier.padding(top = 4.dp, start = 3.dp).testTag("errorText"))
-  }
+        }
+    }
+    if (showError && isError) {
+        Text(
+            errorText,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier
+                .padding(top = 4.dp, start = 3.dp)
+                .testTag("errorText")
+        )
+    }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/search/Announcement.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/Announcement.kt
@@ -64,6 +64,7 @@ fun AnnouncementScreen(navigationActions: NavigationActions, isUser: Boolean = t
     Scaffold(
         containerColor = colorScheme.background,
         topBar = {},
+        modifier = Modifier.testTag("AnnouncementContent"),
         content = { padding ->
           Column(
               modifier =

--- a/app/src/main/java/com/arygm/quickfix/ui/search/Announcement.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/Announcement.kt
@@ -1,6 +1,5 @@
 package com.arygm.quickfix.ui.search
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -45,221 +44,255 @@ import com.arygm.quickfix.ui.elements.QuickFixButton
 import com.arygm.quickfix.ui.elements.QuickFixTextFieldCustom
 import com.arygm.quickfix.ui.navigation.NavigationActions
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AnnouncementScreen(navigationActions: NavigationActions, isUser: Boolean = true) {
 
-  val context = LocalContext.current
-  var title by remember { mutableStateOf("") }
-  var category by remember { mutableStateOf("") }
-  var location by remember { mutableStateOf("") }
-  var description by remember { mutableStateOf("") }
+    var title by remember { mutableStateOf("") }
+    var category by remember { mutableStateOf("") }
+    var location by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
 
-  var titleIsEmpty by remember { mutableStateOf(true) }
-  var categoryIsSelected by remember { mutableStateOf(true) } // TODO: add the different categories
-  var locationIsSelected by remember { mutableStateOf(true) } // TODO: add the implemented location
-  var descriptionIsEmpty by remember { mutableStateOf(true) }
+    var titleIsEmpty by remember { mutableStateOf(true) }
+    var categoryIsSelected by remember { mutableStateOf(true) } // TODO: add the different categories
+    var locationIsSelected by remember { mutableStateOf(true) } // TODO: add the implemented location
+    var descriptionIsEmpty by remember { mutableStateOf(true) }
 
-  BoxWithConstraints {
-    val widthRatio = maxWidth / 411
-    val heightRatio = maxHeight / 860
-    val sizeRatio = minOf(widthRatio, heightRatio)
+    BoxWithConstraints {
+        val widthRatio = maxWidth / 411
+        val heightRatio = maxHeight / 860
+        val sizeRatio = minOf(widthRatio, heightRatio)
 
-    // Use Scaffold for the layout structure
-    Scaffold(
-        containerColor = colorScheme.background,
-        topBar = {},
-        content = { padding ->
-          Column(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .padding(padding)
-                      .padding(top = 30.dp)
-                      .align(Alignment.Center)
-                      .padding(16.dp)
-                      .zIndex(100f)
-                      .verticalScroll(rememberScrollState()),
-              horizontalAlignment = Alignment.CenterHorizontally,
-              verticalArrangement = Arrangement.Center,
-          ) {
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
-            ) {
-              QuickFixTextFieldCustom(
-                  value = title,
-                  onValueChange = {
-                    title = it
-                    titleIsEmpty = title.isEmpty()
-                  },
-                  placeHolderText = "Enter the title of your quickFix",
-                  placeHolderColor = colorScheme.onSecondaryContainer,
-                  shape = RoundedCornerShape(12.dp),
-                  moveContentHorizontal = 10.dp,
-                  heightField = 42.dp,
-                  widthField = 360.dp,
-                  modifier = Modifier.testTag("titleInput"),
-                  showLabel = true,
-                  label = {
-                    Text(
-                        "Title *",
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = colorScheme.onBackground,
-                        modifier = Modifier.padding(start = 3.dp).testTag("titleText"))
-                  })
-            }
+        // Use Scaffold for the layout structure
+        Scaffold(
+            containerColor = colorScheme.background,
+            topBar = {},
+            content = { padding ->
+                Column(
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(padding)
+                        .padding(top = 30.dp)
+                        .align(Alignment.Center)
+                        .padding(16.dp)
+                        .zIndex(100f)
+                        .verticalScroll(rememberScrollState()),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 8.dp),
+                    ) {
+                        QuickFixTextFieldCustom(
+                            value = title,
+                            onValueChange = {
+                                title = it
+                                titleIsEmpty = title.isEmpty()
+                            },
+                            placeHolderText = "Enter the title of your quickFix",
+                            placeHolderColor = colorScheme.onSecondaryContainer,
+                            shape = RoundedCornerShape(12.dp),
+                            moveContentHorizontal = 10.dp,
+                            heightField = 42.dp,
+                            widthField = 360.dp,
+                            modifier = Modifier.testTag("titleInput"),
+                            showLabel = true,
+                            label = {
+                                Text(
+                                    "Title *",
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    color = colorScheme.onBackground,
+                                    modifier = Modifier
+                                        .padding(start = 3.dp)
+                                        .testTag("titleText")
+                                )
+                            })
+                    }
 
-            Spacer(modifier = Modifier.padding(6.dp))
+                    Spacer(modifier = Modifier.padding(6.dp))
 
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
-            ) {
-              QuickFixTextFieldCustom(
-                  value = category,
-                  onValueChange = { category = it },
-                  placeHolderText = "Enter the category",
-                  placeHolderColor = colorScheme.onSecondaryContainer,
-                  shape = RoundedCornerShape(12.dp),
-                  moveContentHorizontal = 10.dp,
-                  heightField = 42.dp,
-                  widthField = 360.dp,
-                  modifier = Modifier.testTag("categoryInput"),
-                  showLabel = true,
-                  label = {
-                    Text(
-                        "Category *",
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = colorScheme.onBackground,
-                        modifier = Modifier.padding(start = 3.dp).testTag("categoryText"))
-                  })
-            }
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 8.dp),
+                    ) {
+                        QuickFixTextFieldCustom(
+                            value = category,
+                            onValueChange = { category = it },
+                            placeHolderText = "Enter the category",
+                            placeHolderColor = colorScheme.onSecondaryContainer,
+                            shape = RoundedCornerShape(12.dp),
+                            moveContentHorizontal = 10.dp,
+                            heightField = 42.dp,
+                            widthField = 360.dp,
+                            modifier = Modifier.testTag("categoryInput"),
+                            showLabel = true,
+                            label = {
+                                Text(
+                                    "Category *",
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    color = colorScheme.onBackground,
+                                    modifier = Modifier
+                                        .padding(start = 3.dp)
+                                        .testTag("categoryText")
+                                )
+                            })
+                    }
 
-            Spacer(modifier = Modifier.padding(6.dp))
+                    Spacer(modifier = Modifier.padding(6.dp))
 
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
-            ) {
-              QuickFixTextFieldCustom(
-                  value = description,
-                  onValueChange = {
-                    description = it
-                    descriptionIsEmpty = description.isEmpty()
-                  },
-                  placeHolderText = "Describe the quickFix",
-                  placeHolderColor = colorScheme.onSecondaryContainer,
-                  shape = RoundedCornerShape(12.dp),
-                  moveContentHorizontal = 10.dp,
-                  heightField = 95.dp,
-                  widthField = 360.dp,
-                  modifier = Modifier.testTag("descriptionInput"),
-                  showLabel = true,
-                  label = {
-                    Text(
-                        "Description *",
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = colorScheme.onBackground,
-                        modifier = Modifier.padding(start = 3.dp).testTag("descriptionText"))
-                  })
-            }
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 8.dp),
+                    ) {
+                        QuickFixTextFieldCustom(
+                            value = description,
+                            onValueChange = {
+                                description = it
+                                descriptionIsEmpty = description.isEmpty()
+                            },
+                            placeHolderText = "Describe the quickFix",
+                            placeHolderColor = colorScheme.onSecondaryContainer,
+                            shape = RoundedCornerShape(12.dp),
+                            moveContentHorizontal = 10.dp,
+                            heightField = 95.dp,
+                            widthField = 360.dp,
+                            modifier = Modifier.testTag("descriptionInput"),
+                            showLabel = true,
+                            label = {
+                                Text(
+                                    "Description *",
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    color = colorScheme.onBackground,
+                                    modifier = Modifier
+                                        .padding(start = 3.dp)
+                                        .testTag("descriptionText")
+                                )
+                            },
+                            singleLine = false
+                        )
+                    }
 
-            Spacer(modifier = Modifier.padding(6.dp))
+                    Spacer(modifier = Modifier.padding(6.dp))
 
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
-            ) {
-              QuickFixTextFieldCustom(
-                  value = location,
-                  onValueChange = { location = it },
-                  placeHolderText = "Enter the location",
-                  placeHolderColor = colorScheme.onSecondaryContainer,
-                  shape = RoundedCornerShape(12.dp),
-                  moveContentHorizontal = 10.dp,
-                  heightField = 42.dp,
-                  widthField = 360.dp,
-                  modifier = Modifier.testTag("locationInput"),
-                  showLabel = true,
-                  label = {
-                    Text(
-                        "Location *",
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = colorScheme.onBackground,
-                        modifier = Modifier.padding(start = 3.dp).testTag("locationText"))
-                  })
-            }
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 8.dp),
+                    ) {
+                        QuickFixTextFieldCustom(
+                            value = location,
+                            onValueChange = { location = it },
+                            placeHolderText = "Enter the location",
+                            placeHolderColor = colorScheme.onSecondaryContainer,
+                            shape = RoundedCornerShape(12.dp),
+                            moveContentHorizontal = 10.dp,
+                            heightField = 42.dp,
+                            widthField = 360.dp,
+                            modifier = Modifier.testTag("locationInput"),
+                            showLabel = true,
+                            label = {
+                                Text(
+                                    "Location *",
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    color = colorScheme.onBackground,
+                                    modifier = Modifier
+                                        .padding(start = 3.dp)
+                                        .testTag("locationText")
+                                )
+                            })
+                    }
 
-            Spacer(modifier = Modifier.padding(10.dp))
+                    Spacer(modifier = Modifier.padding(10.dp))
 
-            QuickFixButtonWithIcon(
-                buttonText = "Availability",
-                onClickAction = {
-                  // TODO: Apply the backend of the pictures
-                },
-                buttonColor = colorScheme.surface,
-                textColor = colorScheme.onBackground,
-                textStyle = MaterialTheme.typography.titleMedium,
-                modifier =
-                    Modifier.width(360.dp)
-                        .height(42.dp)
-                        .testTag("availabilityButton")
-                        .graphicsLayer(alpha = 1f),
-                iconId = R.drawable.calendar,
-                iconContentDescription = "availability",
-                iconColor = colorScheme.onBackground)
+                    QuickFixButtonWithIcon(
+                        buttonText = "Availability",
+                        onClickAction = {
+                            // TODO: Apply the backend of the pictures
+                        },
+                        buttonColor = colorScheme.surface,
+                        textColor = colorScheme.onBackground,
+                        textStyle = MaterialTheme.typography.titleMedium,
+                        modifier =
+                        Modifier
+                            .width(360.dp)
+                            .height(42.dp)
+                            .testTag("availabilityButton")
+                            .graphicsLayer(alpha = 1f),
+                        iconId = R.drawable.calendar,
+                        iconContentDescription = "availability",
+                        iconColor = colorScheme.onBackground
+                    )
 
-            Spacer(modifier = Modifier.padding(10.dp))
+                    Spacer(modifier = Modifier.padding(10.dp))
 
-            QuickFixButtonWithIcon(
-                buttonText = "Upload pictures",
-                onClickAction = {
-                  // TODO: Apply the backend of the pictures
-                },
-                buttonColor = colorScheme.surface,
-                textColor = colorScheme.onBackground,
-                textStyle = MaterialTheme.typography.titleMedium,
-                modifier =
-                    Modifier.width(360.dp)
-                        .height(90.dp)
-                        .testTag("picturesButton")
-                        .graphicsLayer(alpha = 1f),
-                iconId = R.drawable.upload_image,
-                iconContentDescription = "upload_image",
-                iconColor = colorScheme.onBackground)
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).padding(start = 8.dp),
-            ) {
-              Text(
-                  text = "* Mandatory fields",
-                  color =
-                      if (titleIsEmpty ||
-                          !categoryIsSelected ||
-                          !locationIsSelected ||
-                          descriptionIsEmpty)
-                          colorScheme.error
-                      else colorScheme.onSecondaryContainer,
-                  style = MaterialTheme.typography.bodySmall,
-                  modifier = Modifier.padding(start = 9.dp).testTag("mandatoryText"))
-            }
+                    QuickFixButtonWithIcon(
+                        buttonText = "Upload pictures",
+                        onClickAction = {
+                            // TODO: Apply the backend of the pictures
+                        },
+                        buttonColor = colorScheme.surface,
+                        textColor = colorScheme.onBackground,
+                        textStyle = MaterialTheme.typography.titleMedium,
+                        modifier =
+                        Modifier
+                            .width(360.dp)
+                            .height(90.dp)
+                            .testTag("picturesButton")
+                            .graphicsLayer(alpha = 1f),
+                        iconId = R.drawable.upload_image,
+                        iconContentDescription = "upload_image",
+                        iconColor = colorScheme.onBackground
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .padding(start = 8.dp),
+                    ) {
+                        Text(
+                            text = "* Mandatory fields",
+                            color =
+                            if (titleIsEmpty ||
+                                !categoryIsSelected ||
+                                !locationIsSelected ||
+                                descriptionIsEmpty
+                            )
+                                colorScheme.error
+                            else colorScheme.onSecondaryContainer,
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier
+                                .padding(start = 9.dp)
+                                .testTag("mandatoryText")
+                        )
+                    }
 
-            QuickFixButton(
-                buttonText = "Post your announcement",
-                onClickAction = {
-                  // TODO: Apply the backend of the announcement creation
-                },
-                buttonColor = colorScheme.primary,
-                textColor = colorScheme.onPrimary,
-                textStyle = MaterialTheme.typography.titleMedium,
-                modifier =
-                    Modifier.width(360.dp)
-                        .height(55.dp)
-                        .testTag("announcementButton")
-                        .graphicsLayer(alpha = 1f),
-                enabled =
-                    !titleIsEmpty &&
-                        categoryIsSelected &&
-                        locationIsSelected &&
-                        !descriptionIsEmpty)
-          }
-        })
-  }
+                    QuickFixButton(
+                        buttonText = "Post your announcement",
+                        onClickAction = {
+                            // TODO: Apply the backend of the announcement creation
+                        },
+                        buttonColor = colorScheme.primary,
+                        textColor = colorScheme.onPrimary,
+                        textStyle = MaterialTheme.typography.titleMedium,
+                        modifier =
+                        Modifier
+                            .width(360.dp)
+                            .height(55.dp)
+                            .testTag("announcementButton")
+                            .graphicsLayer(alpha = 1f),
+                        enabled =
+                        !titleIsEmpty &&
+                                categoryIsSelected &&
+                                locationIsSelected &&
+                                !descriptionIsEmpty
+                    )
+                }
+            })
+    }
 }
 
 @Composable
@@ -278,34 +311,37 @@ fun QuickFixButtonWithIcon(
     iconContentDescription: String,
     iconColor: Color
 ) {
-  Button(
-      onClick = onClickAction,
-      colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
-      modifier =
-          modifier
-              .fillMaxWidth(0.8f)
-              .height(50.dp)
-              .graphicsLayer(alpha = buttonOpacity)
-              .shadow(
-                  elevation = 2.dp,
-                  shape = RoundedCornerShape(10.dp), // Match the shape with the text field
-                  clip = false // Ensure the shadow is not clipped
-                  )
-              .clip(RoundedCornerShape(10.dp)), // Apply clipping to match the text field
-      shape = RoundedCornerShape(12.dp),
-      contentPadding = contentPadding,
-      enabled = enabled) {
+    Button(
+        onClick = onClickAction,
+        colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
+        modifier =
+        modifier
+            .fillMaxWidth(0.8f)
+            .height(50.dp)
+            .graphicsLayer(alpha = buttonOpacity)
+            .shadow(
+                elevation = 2.dp,
+                shape = RoundedCornerShape(10.dp), // Match the shape with the text field
+                clip = false // Ensure the shadow is not clipped
+            )
+            .clip(RoundedCornerShape(10.dp)), // Apply clipping to match the text field
+        shape = RoundedCornerShape(12.dp),
+        contentPadding = contentPadding,
+        enabled = enabled
+    ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Start) {
-              Icon(
-                  painter = painterResource(id = iconId),
-                  contentDescription = iconContentDescription,
-                  modifier = Modifier.size(20.dp),
-                  tint = iconColor)
-              Spacer(modifier = Modifier.width(80.dp)) // Consistent spacing with the text field
-              Text(text = buttonText, style = textStyle, color = textColor)
-            }
-      }
+            horizontalArrangement = Arrangement.Start
+        ) {
+            Icon(
+                painter = painterResource(id = iconId),
+                contentDescription = iconContentDescription,
+                modifier = Modifier.size(20.dp),
+                tint = iconColor
+            )
+            Spacer(modifier = Modifier.width(80.dp)) // Consistent spacing with the text field
+            Text(text = buttonText, style = textStyle, color = textColor)
+        }
+    }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/search/Announcement.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/Announcement.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
@@ -33,7 +32,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
@@ -47,252 +45,217 @@ import com.arygm.quickfix.ui.navigation.NavigationActions
 @Composable
 fun AnnouncementScreen(navigationActions: NavigationActions, isUser: Boolean = true) {
 
-    var title by remember { mutableStateOf("") }
-    var category by remember { mutableStateOf("") }
-    var location by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
+  var title by remember { mutableStateOf("") }
+  var category by remember { mutableStateOf("") }
+  var location by remember { mutableStateOf("") }
+  var description by remember { mutableStateOf("") }
 
-    var titleIsEmpty by remember { mutableStateOf(true) }
-    var categoryIsSelected by remember { mutableStateOf(true) } // TODO: add the different categories
-    var locationIsSelected by remember { mutableStateOf(true) } // TODO: add the implemented location
-    var descriptionIsEmpty by remember { mutableStateOf(true) }
+  var titleIsEmpty by remember { mutableStateOf(true) }
+  var categoryIsSelected by remember { mutableStateOf(true) } // TODO: add the different categories
+  var locationIsSelected by remember { mutableStateOf(true) } // TODO: add the implemented location
+  var descriptionIsEmpty by remember { mutableStateOf(true) }
 
-    BoxWithConstraints {
-        val widthRatio = maxWidth / 411
-        val heightRatio = maxHeight / 860
-        val sizeRatio = minOf(widthRatio, heightRatio)
+  BoxWithConstraints {
+    val widthRatio = maxWidth / 411
+    val heightRatio = maxHeight / 860
+    val sizeRatio = minOf(widthRatio, heightRatio)
 
-        // Use Scaffold for the layout structure
-        Scaffold(
-            containerColor = colorScheme.background,
-            topBar = {},
-            content = { padding ->
-                Column(
-                    modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(padding)
-                        .padding(top = 30.dp)
-                        .align(Alignment.Center)
-                        .padding(16.dp)
-                        .zIndex(100f)
-                        .verticalScroll(rememberScrollState()),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(start = 8.dp),
-                    ) {
-                        QuickFixTextFieldCustom(
-                            value = title,
-                            onValueChange = {
-                                title = it
-                                titleIsEmpty = title.isEmpty()
-                            },
-                            placeHolderText = "Enter the title of your quickFix",
-                            placeHolderColor = colorScheme.onSecondaryContainer,
-                            shape = RoundedCornerShape(12.dp),
-                            moveContentHorizontal = 10.dp,
-                            heightField = 42.dp,
-                            widthField = 360.dp,
-                            modifier = Modifier.testTag("titleInput"),
-                            showLabel = true,
-                            label = {
-                                Text(
-                                    "Title *",
-                                    style = MaterialTheme.typography.headlineSmall,
-                                    color = colorScheme.onBackground,
-                                    modifier = Modifier
-                                        .padding(start = 3.dp)
-                                        .testTag("titleText")
-                                )
-                            })
-                    }
+    // Use Scaffold for the layout structure
+    Scaffold(
+        containerColor = colorScheme.background,
+        topBar = {},
+        content = { padding ->
+          Column(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(padding)
+                      .padding(top = 30.dp)
+                      .align(Alignment.Center)
+                      .padding(16.dp)
+                      .zIndex(100f)
+                      .verticalScroll(rememberScrollState()),
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.Center,
+          ) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+            ) {
+              QuickFixTextFieldCustom(
+                  value = title,
+                  onValueChange = {
+                    title = it
+                    titleIsEmpty = title.isEmpty()
+                  },
+                  placeHolderText = "Enter the title of your quickFix",
+                  placeHolderColor = colorScheme.onSecondaryContainer,
+                  shape = RoundedCornerShape(12.dp),
+                  moveContentHorizontal = 10.dp,
+                  heightField = 42.dp,
+                  widthField = 360.dp,
+                  modifier = Modifier.testTag("titleInput"),
+                  showLabel = true,
+                  label = {
+                    Text(
+                        "Title *",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 3.dp).testTag("titleText"))
+                  })
+            }
 
-                    Spacer(modifier = Modifier.padding(6.dp))
+            Spacer(modifier = Modifier.padding(6.dp))
 
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(start = 8.dp),
-                    ) {
-                        QuickFixTextFieldCustom(
-                            value = category,
-                            onValueChange = { category = it },
-                            placeHolderText = "Enter the category",
-                            placeHolderColor = colorScheme.onSecondaryContainer,
-                            shape = RoundedCornerShape(12.dp),
-                            moveContentHorizontal = 10.dp,
-                            heightField = 42.dp,
-                            widthField = 360.dp,
-                            modifier = Modifier.testTag("categoryInput"),
-                            showLabel = true,
-                            label = {
-                                Text(
-                                    "Category *",
-                                    style = MaterialTheme.typography.headlineSmall,
-                                    color = colorScheme.onBackground,
-                                    modifier = Modifier
-                                        .padding(start = 3.dp)
-                                        .testTag("categoryText")
-                                )
-                            })
-                    }
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+            ) {
+              QuickFixTextFieldCustom(
+                  value = category,
+                  onValueChange = { category = it },
+                  placeHolderText = "Enter the category",
+                  placeHolderColor = colorScheme.onSecondaryContainer,
+                  shape = RoundedCornerShape(12.dp),
+                  moveContentHorizontal = 10.dp,
+                  heightField = 42.dp,
+                  widthField = 360.dp,
+                  modifier = Modifier.testTag("categoryInput"),
+                  showLabel = true,
+                  label = {
+                    Text(
+                        "Category *",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 3.dp).testTag("categoryText"))
+                  })
+            }
 
-                    Spacer(modifier = Modifier.padding(6.dp))
+            Spacer(modifier = Modifier.padding(6.dp))
 
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(start = 8.dp),
-                    ) {
-                        QuickFixTextFieldCustom(
-                            value = description,
-                            onValueChange = {
-                                description = it
-                                descriptionIsEmpty = description.isEmpty()
-                            },
-                            placeHolderText = "Describe the quickFix",
-                            placeHolderColor = colorScheme.onSecondaryContainer,
-                            shape = RoundedCornerShape(12.dp),
-                            moveContentHorizontal = 10.dp,
-                            heightField = 95.dp,
-                            widthField = 360.dp,
-                            modifier = Modifier.testTag("descriptionInput"),
-                            showLabel = true,
-                            label = {
-                                Text(
-                                    "Description *",
-                                    style = MaterialTheme.typography.headlineSmall,
-                                    color = colorScheme.onBackground,
-                                    modifier = Modifier
-                                        .padding(start = 3.dp)
-                                        .testTag("descriptionText")
-                                )
-                            },
-                            singleLine = false
-                        )
-                    }
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+            ) {
+              QuickFixTextFieldCustom(
+                  value = description,
+                  onValueChange = {
+                    description = it
+                    descriptionIsEmpty = description.isEmpty()
+                  },
+                  placeHolderText = "Describe the quickFix",
+                  placeHolderColor = colorScheme.onSecondaryContainer,
+                  shape = RoundedCornerShape(12.dp),
+                  moveContentHorizontal = 10.dp,
+                  heightField = 95.dp,
+                  widthField = 360.dp,
+                  modifier = Modifier.testTag("descriptionInput"),
+                  showLabel = true,
+                  label = {
+                    Text(
+                        "Description *",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 3.dp).testTag("descriptionText"))
+                  },
+                  singleLine = false)
+            }
 
-                    Spacer(modifier = Modifier.padding(6.dp))
+            Spacer(modifier = Modifier.padding(6.dp))
 
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(start = 8.dp),
-                    ) {
-                        QuickFixTextFieldCustom(
-                            value = location,
-                            onValueChange = { location = it },
-                            placeHolderText = "Enter the location",
-                            placeHolderColor = colorScheme.onSecondaryContainer,
-                            shape = RoundedCornerShape(12.dp),
-                            moveContentHorizontal = 10.dp,
-                            heightField = 42.dp,
-                            widthField = 360.dp,
-                            modifier = Modifier.testTag("locationInput"),
-                            showLabel = true,
-                            label = {
-                                Text(
-                                    "Location *",
-                                    style = MaterialTheme.typography.headlineSmall,
-                                    color = colorScheme.onBackground,
-                                    modifier = Modifier
-                                        .padding(start = 3.dp)
-                                        .testTag("locationText")
-                                )
-                            })
-                    }
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+            ) {
+              QuickFixTextFieldCustom(
+                  value = location,
+                  onValueChange = { location = it },
+                  placeHolderText = "Enter the location",
+                  placeHolderColor = colorScheme.onSecondaryContainer,
+                  shape = RoundedCornerShape(12.dp),
+                  moveContentHorizontal = 10.dp,
+                  heightField = 42.dp,
+                  widthField = 360.dp,
+                  modifier = Modifier.testTag("locationInput"),
+                  showLabel = true,
+                  label = {
+                    Text(
+                        "Location *",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 3.dp).testTag("locationText"))
+                  })
+            }
 
-                    Spacer(modifier = Modifier.padding(10.dp))
+            Spacer(modifier = Modifier.padding(10.dp))
 
-                    QuickFixButtonWithIcon(
-                        buttonText = "Availability",
-                        onClickAction = {
-                            // TODO: Apply the backend of the pictures
-                        },
-                        buttonColor = colorScheme.surface,
-                        textColor = colorScheme.onBackground,
-                        textStyle = MaterialTheme.typography.titleMedium,
-                        modifier =
-                        Modifier
-                            .width(360.dp)
-                            .height(42.dp)
-                            .testTag("availabilityButton")
-                            .graphicsLayer(alpha = 1f),
-                        iconId = R.drawable.calendar,
-                        iconContentDescription = "availability",
-                        iconColor = colorScheme.onBackground
-                    )
+            QuickFixButtonWithIcon(
+                buttonText = "Availability",
+                onClickAction = {
+                  // TODO: Apply the backend of the pictures
+                },
+                buttonColor = colorScheme.surface,
+                textColor = colorScheme.onBackground,
+                textStyle = MaterialTheme.typography.titleMedium,
+                modifier =
+                    Modifier.width(360.dp)
+                        .height(42.dp)
+                        .testTag("availabilityButton")
+                        .graphicsLayer(alpha = 1f),
+                iconId = R.drawable.calendar,
+                iconContentDescription = "availability",
+                iconColor = colorScheme.onBackground)
 
-                    Spacer(modifier = Modifier.padding(10.dp))
+            Spacer(modifier = Modifier.padding(10.dp))
 
-                    QuickFixButtonWithIcon(
-                        buttonText = "Upload pictures",
-                        onClickAction = {
-                            // TODO: Apply the backend of the pictures
-                        },
-                        buttonColor = colorScheme.surface,
-                        textColor = colorScheme.onBackground,
-                        textStyle = MaterialTheme.typography.titleMedium,
-                        modifier =
-                        Modifier
-                            .width(360.dp)
-                            .height(90.dp)
-                            .testTag("picturesButton")
-                            .graphicsLayer(alpha = 1f),
-                        iconId = R.drawable.upload_image,
-                        iconContentDescription = "upload_image",
-                        iconColor = colorScheme.onBackground
-                    )
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp)
-                            .padding(start = 8.dp),
-                    ) {
-                        Text(
-                            text = "* Mandatory fields",
-                            color =
-                            if (titleIsEmpty ||
-                                !categoryIsSelected ||
-                                !locationIsSelected ||
-                                descriptionIsEmpty
-                            )
-                                colorScheme.error
-                            else colorScheme.onSecondaryContainer,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier
-                                .padding(start = 9.dp)
-                                .testTag("mandatoryText")
-                        )
-                    }
+            QuickFixButtonWithIcon(
+                buttonText = "Upload pictures",
+                onClickAction = {
+                  // TODO: Apply the backend of the pictures
+                },
+                buttonColor = colorScheme.surface,
+                textColor = colorScheme.onBackground,
+                textStyle = MaterialTheme.typography.titleMedium,
+                modifier =
+                    Modifier.width(360.dp)
+                        .height(90.dp)
+                        .testTag("picturesButton")
+                        .graphicsLayer(alpha = 1f),
+                iconId = R.drawable.upload_image,
+                iconContentDescription = "upload_image",
+                iconColor = colorScheme.onBackground)
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).padding(start = 8.dp),
+            ) {
+              Text(
+                  text = "* Mandatory fields",
+                  color =
+                      if (titleIsEmpty ||
+                          !categoryIsSelected ||
+                          !locationIsSelected ||
+                          descriptionIsEmpty)
+                          colorScheme.error
+                      else colorScheme.onSecondaryContainer,
+                  style = MaterialTheme.typography.bodySmall,
+                  modifier = Modifier.padding(start = 9.dp).testTag("mandatoryText"))
+            }
 
-                    QuickFixButton(
-                        buttonText = "Post your announcement",
-                        onClickAction = {
-                            // TODO: Apply the backend of the announcement creation
-                        },
-                        buttonColor = colorScheme.primary,
-                        textColor = colorScheme.onPrimary,
-                        textStyle = MaterialTheme.typography.titleMedium,
-                        modifier =
-                        Modifier
-                            .width(360.dp)
-                            .height(55.dp)
-                            .testTag("announcementButton")
-                            .graphicsLayer(alpha = 1f),
-                        enabled =
-                        !titleIsEmpty &&
-                                categoryIsSelected &&
-                                locationIsSelected &&
-                                !descriptionIsEmpty
-                    )
-                }
-            })
-    }
+            QuickFixButton(
+                buttonText = "Post your announcement",
+                onClickAction = {
+                  // TODO: Apply the backend of the announcement creation
+                },
+                buttonColor = colorScheme.primary,
+                textColor = colorScheme.onPrimary,
+                textStyle = MaterialTheme.typography.titleMedium,
+                modifier =
+                    Modifier.width(360.dp)
+                        .height(55.dp)
+                        .testTag("announcementButton")
+                        .graphicsLayer(alpha = 1f),
+                enabled =
+                    !titleIsEmpty &&
+                        categoryIsSelected &&
+                        locationIsSelected &&
+                        !descriptionIsEmpty)
+          }
+        })
+  }
 }
 
 @Composable
@@ -311,37 +274,34 @@ fun QuickFixButtonWithIcon(
     iconContentDescription: String,
     iconColor: Color
 ) {
-    Button(
-        onClick = onClickAction,
-        colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
-        modifier =
-        modifier
-            .fillMaxWidth(0.8f)
-            .height(50.dp)
-            .graphicsLayer(alpha = buttonOpacity)
-            .shadow(
-                elevation = 2.dp,
-                shape = RoundedCornerShape(10.dp), // Match the shape with the text field
-                clip = false // Ensure the shadow is not clipped
-            )
-            .clip(RoundedCornerShape(10.dp)), // Apply clipping to match the text field
-        shape = RoundedCornerShape(12.dp),
-        contentPadding = contentPadding,
-        enabled = enabled
-    ) {
+  Button(
+      onClick = onClickAction,
+      colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
+      modifier =
+          modifier
+              .fillMaxWidth(0.8f)
+              .height(50.dp)
+              .graphicsLayer(alpha = buttonOpacity)
+              .shadow(
+                  elevation = 2.dp,
+                  shape = RoundedCornerShape(10.dp), // Match the shape with the text field
+                  clip = false // Ensure the shadow is not clipped
+                  )
+              .clip(RoundedCornerShape(10.dp)), // Apply clipping to match the text field
+      shape = RoundedCornerShape(12.dp),
+      contentPadding = contentPadding,
+      enabled = enabled) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Start
-        ) {
-            Icon(
-                painter = painterResource(id = iconId),
-                contentDescription = iconContentDescription,
-                modifier = Modifier.size(20.dp),
-                tint = iconColor
-            )
-            Spacer(modifier = Modifier.width(80.dp)) // Consistent spacing with the text field
-            Text(text = buttonText, style = textStyle, color = textColor)
-        }
-    }
+            horizontalArrangement = Arrangement.Start) {
+              Icon(
+                  painter = painterResource(id = iconId),
+                  contentDescription = iconContentDescription,
+                  modifier = Modifier.size(20.dp),
+                  tint = iconColor)
+              Spacer(modifier = Modifier.width(80.dp)) // Consistent spacing with the text field
+              Text(text = buttonText, style = textStyle, color = textColor)
+            }
+      }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/search/Announcement.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/Announcement.kt
@@ -1,33 +1,311 @@
 package com.arygm.quickfix.ui.search
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.arygm.quickfix.R
+import com.arygm.quickfix.ui.elements.QuickFixButton
+import com.arygm.quickfix.ui.elements.QuickFixTextFieldCustom
 import com.arygm.quickfix.ui.navigation.NavigationActions
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AnnouncementScreen(navigationActions: NavigationActions, isUser: Boolean = true) {
-  // Use Scaffold for the layout structure
-  Scaffold(
-      containerColor = colorScheme.background,
-      content = { padding ->
-        Column(
-            modifier = Modifier.fillMaxSize().testTag("AnnouncementContent"),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally) {
-              Text(
-                  text = "Welcome to the Announcement Screen",
-                  modifier = Modifier.padding(padding).testTag("AnnouncementText"))
+
+  val context = LocalContext.current
+  var title by remember { mutableStateOf("") }
+  var category by remember { mutableStateOf("") }
+  var location by remember { mutableStateOf("") }
+  var description by remember { mutableStateOf("") }
+
+  var titleIsEmpty by remember { mutableStateOf(true) }
+  var categoryIsSelected by remember { mutableStateOf(true) } // TODO: add the different categories
+  var locationIsSelected by remember { mutableStateOf(true) } // TODO: add the implemented location
+  var descriptionIsEmpty by remember { mutableStateOf(true) }
+
+  BoxWithConstraints {
+    val widthRatio = maxWidth / 411
+    val heightRatio = maxHeight / 860
+    val sizeRatio = minOf(widthRatio, heightRatio)
+
+    // Use Scaffold for the layout structure
+    Scaffold(
+        containerColor = colorScheme.background,
+        topBar = {},
+        content = { padding ->
+          Column(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(padding)
+                      .padding(top = 30.dp)
+                      .align(Alignment.Center)
+                      .padding(16.dp)
+                      .zIndex(100f)
+                      .verticalScroll(rememberScrollState()),
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.Center,
+          ) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+            ) {
+              QuickFixTextFieldCustom(
+                  value = title,
+                  onValueChange = {
+                    title = it
+                    titleIsEmpty = title.isEmpty()
+                  },
+                  placeHolderText = "Enter the title of your quickFix",
+                  placeHolderColor = colorScheme.onSecondaryContainer,
+                  shape = RoundedCornerShape(12.dp),
+                  moveContentHorizontal = 10.dp,
+                  heightField = 42.dp,
+                  widthField = 360.dp,
+                  modifier = Modifier.testTag("titleInput"),
+                  showLabel = true,
+                  label = {
+                    Text(
+                        "Title *",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 3.dp).testTag("titleText"))
+                  })
             }
-      })
+
+            Spacer(modifier = Modifier.padding(6.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+            ) {
+              QuickFixTextFieldCustom(
+                  value = category,
+                  onValueChange = { category = it },
+                  placeHolderText = "Enter the category",
+                  placeHolderColor = colorScheme.onSecondaryContainer,
+                  shape = RoundedCornerShape(12.dp),
+                  moveContentHorizontal = 10.dp,
+                  heightField = 42.dp,
+                  widthField = 360.dp,
+                  modifier = Modifier.testTag("categoryInput"),
+                  showLabel = true,
+                  label = {
+                    Text(
+                        "Category *",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 3.dp).testTag("categoryText"))
+                  })
+            }
+
+            Spacer(modifier = Modifier.padding(6.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+            ) {
+              QuickFixTextFieldCustom(
+                  value = description,
+                  onValueChange = {
+                    description = it
+                    descriptionIsEmpty = description.isEmpty()
+                  },
+                  placeHolderText = "Describe the quickFix",
+                  placeHolderColor = colorScheme.onSecondaryContainer,
+                  shape = RoundedCornerShape(12.dp),
+                  moveContentHorizontal = 10.dp,
+                  heightField = 95.dp,
+                  widthField = 360.dp,
+                  modifier = Modifier.testTag("descriptionInput"),
+                  showLabel = true,
+                  label = {
+                    Text(
+                        "Description *",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 3.dp).testTag("descriptionText"))
+                  })
+            }
+
+            Spacer(modifier = Modifier.padding(6.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+            ) {
+              QuickFixTextFieldCustom(
+                  value = location,
+                  onValueChange = { location = it },
+                  placeHolderText = "Enter the location",
+                  placeHolderColor = colorScheme.onSecondaryContainer,
+                  shape = RoundedCornerShape(12.dp),
+                  moveContentHorizontal = 10.dp,
+                  heightField = 42.dp,
+                  widthField = 360.dp,
+                  modifier = Modifier.testTag("locationInput"),
+                  showLabel = true,
+                  label = {
+                    Text(
+                        "Location *",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 3.dp).testTag("locationText"))
+                  })
+            }
+
+            Spacer(modifier = Modifier.padding(10.dp))
+
+            QuickFixButtonWithIcon(
+                buttonText = "Availability",
+                onClickAction = {
+                  // TODO: Apply the backend of the pictures
+                },
+                buttonColor = colorScheme.surface,
+                textColor = colorScheme.onBackground,
+                textStyle = MaterialTheme.typography.titleMedium,
+                modifier =
+                    Modifier.width(360.dp)
+                        .height(42.dp)
+                        .testTag("availabilityButton")
+                        .graphicsLayer(alpha = 1f),
+                iconId = R.drawable.calendar,
+                iconContentDescription = "availability",
+                iconColor = colorScheme.onBackground)
+
+            Spacer(modifier = Modifier.padding(10.dp))
+
+            QuickFixButtonWithIcon(
+                buttonText = "Upload pictures",
+                onClickAction = {
+                  // TODO: Apply the backend of the pictures
+                },
+                buttonColor = colorScheme.surface,
+                textColor = colorScheme.onBackground,
+                textStyle = MaterialTheme.typography.titleMedium,
+                modifier =
+                    Modifier.width(360.dp)
+                        .height(90.dp)
+                        .testTag("picturesButton")
+                        .graphicsLayer(alpha = 1f),
+                iconId = R.drawable.upload_image,
+                iconContentDescription = "upload_image",
+                iconColor = colorScheme.onBackground)
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).padding(start = 8.dp),
+            ) {
+              Text(
+                  text = "* Mandatory fields",
+                  color =
+                      if (titleIsEmpty ||
+                          !categoryIsSelected ||
+                          !locationIsSelected ||
+                          descriptionIsEmpty)
+                          colorScheme.error
+                      else colorScheme.onSecondaryContainer,
+                  style = MaterialTheme.typography.bodySmall,
+                  modifier = Modifier.padding(start = 9.dp).testTag("mandatoryText"))
+            }
+
+            QuickFixButton(
+                buttonText = "Post your announcement",
+                onClickAction = {
+                  // TODO: Apply the backend of the announcement creation
+                },
+                buttonColor = colorScheme.primary,
+                textColor = colorScheme.onPrimary,
+                textStyle = MaterialTheme.typography.titleMedium,
+                modifier =
+                    Modifier.width(360.dp)
+                        .height(55.dp)
+                        .testTag("announcementButton")
+                        .graphicsLayer(alpha = 1f),
+                enabled =
+                    !titleIsEmpty &&
+                        categoryIsSelected &&
+                        locationIsSelected &&
+                        !descriptionIsEmpty)
+          }
+        })
+  }
+}
+
+@Composable
+fun QuickFixButtonWithIcon(
+    buttonText: String,
+    onClickAction: () -> Unit,
+    buttonColor: Color,
+    buttonOpacity: Float = 1f,
+    textColor: Color,
+    textStyle: TextStyle = MaterialTheme.typography.labelMedium,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Center,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    iconId: Int,
+    iconContentDescription: String,
+    iconColor: Color
+) {
+  Button(
+      onClick = onClickAction,
+      colors = ButtonDefaults.buttonColors(containerColor = buttonColor),
+      modifier =
+          modifier
+              .fillMaxWidth(0.8f)
+              .height(50.dp)
+              .graphicsLayer(alpha = buttonOpacity)
+              .shadow(
+                  elevation = 2.dp,
+                  shape = RoundedCornerShape(10.dp), // Match the shape with the text field
+                  clip = false // Ensure the shadow is not clipped
+                  )
+              .clip(RoundedCornerShape(10.dp)), // Apply clipping to match the text field
+      shape = RoundedCornerShape(12.dp),
+      contentPadding = contentPadding,
+      enabled = enabled) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Start) {
+              Icon(
+                  painter = painterResource(id = iconId),
+                  contentDescription = iconContentDescription,
+                  modifier = Modifier.size(20.dp),
+                  tint = iconColor)
+              Spacer(modifier = Modifier.width(80.dp)) // Consistent spacing with the text field
+              Text(text = buttonText, style = textStyle, color = textColor)
+            }
+      }
 }

--- a/app/src/main/res/drawable/calendar.xml
+++ b/app/src/main/res/drawable/calendar.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="22dp"
+    android:height="15dp"
+    android:viewportWidth="22"
+    android:viewportHeight="15">
+  <group>
+    <clip-path
+        android:pathData="M0,0h22v15h-22z"/>
+    <path
+        android:strokeWidth="1"
+        android:pathData="M14.667,1.25V3.75M7.333,1.25V3.75M2.75,6.25H19.25M4.583,2.5H17.417C18.429,2.5 19.25,3.06 19.25,3.75V12.5C19.25,13.19 18.429,13.75 17.417,13.75H4.583C3.571,13.75 2.75,13.19 2.75,12.5V3.75C2.75,3.06 3.571,2.5 4.583,2.5Z"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#1E1E1E"
+        android:strokeLineCap="round"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/upload_image.xml
+++ b/app/src/main/res/drawable/upload_image.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="17dp"
+    android:viewportWidth="17"
+    android:viewportHeight="17">
+  <path
+      android:pathData="M12.75,10.2V12.75H10.2V14.45H12.75V17H14.45V14.45H17V12.75H14.45V10.2H12.75ZM8.755,15.3H1.7C0.765,15.3 0,14.535 0,13.6V1.7C0,0.765 0.765,0 1.7,0H13.6C14.535,0 15.3,0.765 15.3,1.7V8.755C14.79,8.585 14.195,8.5 13.6,8.5C12.665,8.5 11.73,8.755 10.965,9.265L9.775,7.65L6.8,11.475L4.675,8.925L1.7,12.75H8.585C8.5,13.005 8.5,13.345 8.5,13.6C8.5,14.195 8.585,14.79 8.755,15.3Z"
+      android:fillColor="#000000"/>
+</vector>


### PR DESCRIPTION
This pull request implements the Announcement screen according to the Figma design. It includes the layout, structure, and necessary fields such as title, category, description, and location. The screen also includes buttons for availability and uploading pictures, though the functionality for these buttons is yet to be implemented.

![Capture d'écran 2024-11-09 220518](https://github.com/user-attachments/assets/6382871d-f9e3-48ce-baaa-4a6db872ded4)
Related to #123 

Next steps will involve building the composables for managing availability and uploading pictures, which are essential features for completing the Announcement screen functionality.

The PR also includes tests to ensure the proper behavior of the screen components.