### PR TITLE
Import missing in end2end Test

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/kaspresso/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/kaspresso/MainActivityTest.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import android.util.Log
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals


### PR DESCRIPTION
Strange for this fix since all the tests were ran before merging #136, but surprisingly an import was missing despite the fact that the CI passed before merging. 