### PR TITLE
feat: Implement ChooseServiceTypeSheet and UI tests for service selection

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/ChooseServiceTypeSheetTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/ChooseServiceTypeSheetTest.kt
@@ -1,0 +1,158 @@
+package com.arygm.quickfix.ui.elements
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.arygm.quickfix.ui.theme.QuickFixTheme
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class ChooseServiceTypeSheetTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var onDismissRequest: () -> Unit
+  private lateinit var onServiceSelect: (String) -> Unit
+  private lateinit var onApplyClick: () -> Unit
+  private lateinit var onResetClick: () -> Unit
+
+  @Before
+  fun setup() {
+    onDismissRequest = mock()
+    onServiceSelect = mock()
+    onApplyClick = mock()
+    onResetClick = mock()
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun chooseServiceTypeSheet_displaysCorrectly() {
+    val serviceTypes = listOf("Exterior Painter", "Interior Painter")
+    composeTestRule.setContent {
+      QuickFixTheme {
+        ChooseServiceTypeSheet(
+            showModalBottomSheet = true,
+            serviceTypes = serviceTypes,
+            selectedService = "Exterior Painter",
+            onServiceSelect = onServiceSelect,
+            onApplyClick = onApplyClick,
+            onResetClick = onResetClick,
+            onDismissRequest = onDismissRequest)
+      }
+    }
+
+    // Assert the dialog is displayed
+    composeTestRule.onNodeWithTag("serviceTypeText").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Service Type").assertIsDisplayed()
+
+    // Assert divider is displayed
+    composeTestRule.onNodeWithTag("serviceTypeText").assertIsDisplayed()
+
+    // Assert each service type is displayed
+    serviceTypes.forEach { service ->
+      composeTestRule.onNodeWithTag("serviceText_$service").assertIsDisplayed()
+      composeTestRule.onNodeWithText(service).assertIsDisplayed()
+    }
+
+    // Assert Apply and Reset buttons are displayed
+    composeTestRule.onNodeWithTag("applyButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("resetButton").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Apply").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Reset").assertIsDisplayed()
+  }
+
+  @Test
+  fun chooseServiceTypeSheet_applyButtonClick_invokesCallback() {
+    val serviceTypes = listOf("Exterior Painter", "Interior Painter")
+    composeTestRule.setContent {
+      QuickFixTheme {
+        ChooseServiceTypeSheet(
+            showModalBottomSheet = true,
+            serviceTypes = serviceTypes,
+            selectedService = "Exterior Painter",
+            onServiceSelect = onServiceSelect,
+            onApplyClick = onApplyClick,
+            onResetClick = onResetClick,
+            onDismissRequest = onDismissRequest)
+      }
+    }
+
+    // Click on Apply button
+    composeTestRule.onNodeWithTag("applyButton").performClick()
+
+    // Verify the apply callback is triggered
+    verify(onApplyClick).invoke()
+  }
+
+  @Test
+  fun chooseServiceTypeSheet_resetButtonClick_invokesCallback() {
+    val serviceTypes = listOf("Exterior Painter", "Interior Painter")
+    composeTestRule.setContent {
+      QuickFixTheme {
+        ChooseServiceTypeSheet(
+            showModalBottomSheet = true,
+            serviceTypes = serviceTypes,
+            selectedService = "Exterior Painter",
+            onServiceSelect = onServiceSelect,
+            onApplyClick = onApplyClick,
+            onResetClick = onResetClick,
+            onDismissRequest = onDismissRequest)
+      }
+    }
+
+    // Click on Reset button
+    composeTestRule.onNodeWithTag("resetButton").performClick()
+
+    // Verify the reset callback is triggered
+    verify(onResetClick).invoke()
+  }
+
+  @Test
+  fun chooseServiceTypeSheet_serviceSelect_invokesCallback() {
+    val serviceTypes = listOf("Exterior Painter", "Interior Painter")
+    composeTestRule.setContent {
+      QuickFixTheme {
+        ChooseServiceTypeSheet(
+            showModalBottomSheet = true,
+            serviceTypes = serviceTypes,
+            selectedService = "",
+            onServiceSelect = onServiceSelect,
+            onApplyClick = onApplyClick,
+            onResetClick = onResetClick,
+            onDismissRequest = onDismissRequest)
+      }
+    }
+
+    // Click on a service type
+    composeTestRule.onNodeWithTag("serviceText_Exterior Painter").performClick()
+
+    // Verify the service select callback is triggered with the correct parameter
+    verify(onServiceSelect).invoke("Exterior Painter")
+  }
+
+  @Test
+  fun chooseServiceTypeSheet_notDisplayedWhenShowModalBottomSheetIsFalse() {
+    val serviceTypes = listOf("Exterior Painter", "Interior Painter")
+    composeTestRule.setContent {
+      QuickFixTheme {
+        ChooseServiceTypeSheet(
+            showModalBottomSheet = false,
+            serviceTypes = serviceTypes,
+            selectedService = "",
+            onServiceSelect = onServiceSelect,
+            onApplyClick = onApplyClick,
+            onResetClick = onResetClick,
+            onDismissRequest = onDismissRequest)
+      }
+    }
+
+    // Assert the dialog is not displayed
+    composeTestRule.onNodeWithTag("serviceTypeText").assertDoesNotExist()
+  }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuiickFixServicesChoosing.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuiickFixServicesChoosing.kt
@@ -1,0 +1,168 @@
+package com.arygm.quickfix.ui.elements
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.arygm.quickfix.ui.theme.QuickFixTheme
+
+/**
+ * A composable function that displays a modal sheet for selecting a service type. It includes a
+ * list of service options, an "Apply" button, and a "Reset" option. The sheet uses relative
+ * dimensions for responsiveness across various screen sizes.
+ *
+ * @param showModalBottomSheet Controls the visibility of the modal sheet.
+ * @param serviceTypes List of service types to display as selectable options.
+ * @param selectedService The currently selected service.
+ * @param onServiceSelect Callback triggered when a service option is selected.
+ * @param onApplyClick Callback triggered when the "Apply" button is clicked.
+ * @param onResetClick Callback triggered when the "Reset" text is clicked.
+ * @param onDismissRequest Callback triggered when the modal sheet is dismissed.
+ */
+@Composable
+fun ChooseServiceTypeSheet(
+    showModalBottomSheet: Boolean,
+    serviceTypes: List<String>,
+    selectedService: String,
+    onServiceSelect: (String) -> Unit,
+    onApplyClick: () -> Unit,
+    onResetClick: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+  if (showModalBottomSheet) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false)) {
+          BoxWithConstraints {
+            val paddingHorizontal = maxWidth * 0.04f // Relative horizontal padding (4% of width)
+            val verticalSpacing = maxHeight * 0.015f // Relative vertical spacing (1.5% of height)
+            val cornerRadius = maxWidth * 0.05f // Rounded corner radius (5% of width)
+            val buttonPaddingHorizontal = maxWidth * 0.04f // Button padding (4% of width)
+
+            Column(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .background(
+                            colorScheme.surface,
+                            RoundedCornerShape(topStart = cornerRadius, topEnd = cornerRadius))
+                        .padding(horizontal = 0.dp)
+                        .testTag("chooseServiceTypeDialog"),
+                horizontalAlignment = Alignment.CenterHorizontally) {
+
+                  // Title of the sheet
+                  Text(
+                      text = "Service Type",
+                      style = MaterialTheme.typography.headlineLarge,
+                      color = colorScheme.outline,
+                      modifier = Modifier.testTag("serviceTypeText"))
+
+                  Spacer(modifier = Modifier.height(verticalSpacing)) // Space below title
+
+                  // Full-width divider under the title
+                  Divider(
+                      color = colorScheme.onSecondaryContainer,
+                      thickness = 1.dp,
+                      modifier = Modifier.fillMaxWidth())
+
+                  Spacer(modifier = Modifier.height(verticalSpacing)) // Space below divider
+
+                  // Display each service option in a row
+                  Row(
+                      modifier = Modifier.fillMaxWidth().padding(verticalSpacing),
+                      horizontalArrangement =
+                          Arrangement.spacedBy(paddingHorizontal, Alignment.CenterHorizontally)) {
+                        serviceTypes.forEach { service ->
+                          val isSelected = service == selectedService
+                          Text(
+                              text = service,
+                              style = MaterialTheme.typography.bodyMedium,
+                              modifier =
+                                  Modifier.clickable { onServiceSelect(service) }
+                                      .background(
+                                          color =
+                                              if (isSelected) colorScheme.primary
+                                              else colorScheme.secondary,
+                                          shape = RoundedCornerShape(cornerRadius))
+                                      .padding(
+                                          horizontal =
+                                              paddingHorizontal *
+                                                  1.5f, // Extra padding inside each option
+                                          vertical = verticalSpacing)
+                                      .testTag("serviceText_$service"),
+                              color =
+                                  if (isSelected) colorScheme.onPrimary
+                                  else colorScheme.onSecondary)
+                        }
+                      }
+
+                  Spacer(
+                      modifier =
+                          Modifier.height(verticalSpacing * 1.5f)) // Space before Apply button
+
+                  // Apply button to confirm the selection
+                  Button(
+                      onClick = onApplyClick,
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .padding(horizontal = buttonPaddingHorizontal)
+                              .testTag("applyButton"),
+                      colors =
+                          androidx.compose.material3.ButtonDefaults.buttonColors(
+                              containerColor = colorScheme.primary,
+                              contentColor = colorScheme.onPrimary)) {
+                        Text("Apply")
+                      }
+
+                  Spacer(
+                      modifier = Modifier.height(verticalSpacing)) // Space between Apply and Reset
+
+                  // Reset option to clear the selection
+                  Text(
+                      text = "Reset",
+                      color = colorScheme.onSecondaryContainer,
+                      modifier =
+                          Modifier.clickable { onResetClick() }
+                              .padding(vertical = verticalSpacing / 2)
+                              .testTag("resetButton"))
+                }
+          }
+        }
+  }
+}
+
+/**
+ * Preview function to display the ChooseServiceTypeSheet in the UI editor. Sets up initial values
+ * for testing and previewing the component.
+ */
+@Preview(showBackground = true)
+@Composable
+fun ChooseServiceTypePreview() {
+  var selectedService by remember { mutableStateOf("Exterior Painter") }
+  var showModal by remember { mutableStateOf(true) }
+
+  val serviceTypes = listOf("Exterior Painter", "Interior Painter")
+
+  QuickFixTheme {
+    ChooseServiceTypeSheet(
+        showModalBottomSheet = showModal,
+        serviceTypes = serviceTypes,
+        selectedService = selectedService,
+        onServiceSelect = { selectedService = it },
+        onApplyClick = { /* Handle Apply */},
+        onResetClick = { selectedService = "" },
+        onDismissRequest = { showModal = false })
+  }
+}


### PR DESCRIPTION
feat: Implement ChooseServiceTypeSheet and UI tests for service selection modal

- Added `ChooseServiceTypeSheet` component in QuiickFixServicesChoosing.kt, providing a dynamic modal UI for selecting service types with customizable options.
- Created `ChooseServiceTypeSheetTest` in ChooseServiceTypeSheetTest.kt to validate UI interactions, including service selection, Apply, and Reset actions.
- Used relative dimensions in the `ChooseServiceTypeSheet` component for better responsiveness across screen sizes.

Related to issue #151
<img width="173" alt="servicetypescreen" src="https://github.com/user-attachments/assets/a7f20e09-4f5f-4453-b1ea-9abaa2dd436e">
