### PR TITLE
feat: Add a state for the mode of usage

### DIFF
--- a/app/src/main/java/com/arygm/quickfix/model/account/LoggedInAccountViewModel.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/account/LoggedInAccountViewModel.kt
@@ -68,10 +68,6 @@ class LoggedInAccountViewModel(
   }
 
   fun switch_mode() {
-    if (mode_.value == Mode.USER) {
-      mode_.value = Mode.WORKER
-    } else {
-      mode_.value = Mode.USER
-    }
+      mode_.value = Mode.entries.toTypedArray()[(mode_.value.ordinal + 1) % Mode.entries.size]
   }
 }

--- a/app/src/main/java/com/arygm/quickfix/model/account/LoggedInAccountViewModel.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/account/LoggedInAccountViewModel.kt
@@ -19,12 +19,19 @@ class LoggedInAccountViewModel(
     private val workerProfileRepo: ProfileRepository
 ) : ViewModel() {
 
+  enum class Mode {
+    USER,
+    WORKER
+  }
+
   val loggedInAccount_ = MutableStateFlow<Account?>(null)
   val loggedInAccount: StateFlow<Account?> = loggedInAccount_.asStateFlow()
   val userProfile_ = MutableStateFlow<UserProfile?>(null)
   val userProfile: StateFlow<UserProfile?> = userProfile_.asStateFlow()
   val workerProfile_ = MutableStateFlow<WorkerProfile?>(null)
   val workerProfile: StateFlow<WorkerProfile?> = workerProfile_.asStateFlow()
+  val mode_ = MutableStateFlow<Mode>(Mode.USER)
+  val mode: StateFlow<Mode> = mode_.asStateFlow()
 
   companion object {
     val Factory: ViewModelProvider.Factory =
@@ -58,5 +65,13 @@ class LoggedInAccountViewModel(
     userProfile_.value = null
     workerProfile_.value = null
     com.arygm.quickfix.utils.logOut(firebaseAuth)
+  }
+
+  fun switch_mode() {
+    if (mode_.value == Mode.USER) {
+      mode_.value = Mode.WORKER
+    } else {
+      mode_.value = Mode.USER
+    }
   }
 }

--- a/app/src/test/java/com/arygm/quickfix/model/account/LoggedInAccountViewModelTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/account/LoggedInAccountViewModelTest.kt
@@ -521,4 +521,47 @@ class LoggedInAccountViewModelTest {
     composeTestRule.onNodeWithTag("ChangePasswordButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("SaveButton").assertIsDisplayed()
   }
+
+  @Test
+  fun defaultModeShouldBeUser() {
+    // Assert the default mode is USER
+    assertEquals(LoggedInAccountViewModel.Mode.USER, loggedInAccountViewModel.mode.value)
+  }
+
+  @Test
+  fun switchModeFromUserToWorker() {
+    // Act: Call switch_mode once
+    loggedInAccountViewModel.switch_mode()
+
+    // Assert: Mode should now be WORKER
+    assertEquals(LoggedInAccountViewModel.Mode.WORKER, loggedInAccountViewModel.mode.value)
+  }
+
+  @Test
+  fun switchModeFromWorkerToUser() {
+    // Arrange: Set mode to WORKER first
+    loggedInAccountViewModel.switch_mode()
+    assertEquals(LoggedInAccountViewModel.Mode.WORKER, loggedInAccountViewModel.mode.value)
+
+    // Act: Call switch_mode again
+    loggedInAccountViewModel.switch_mode()
+
+    // Assert: Mode should now be USER
+    assertEquals(LoggedInAccountViewModel.Mode.USER, loggedInAccountViewModel.mode.value)
+  }
+
+  @Test
+  fun multipleModeSwitches() {
+    // Act & Assert: Call switch_mode multiple times and verify the mode alternates
+    assertEquals(LoggedInAccountViewModel.Mode.USER, loggedInAccountViewModel.mode.value)
+
+    loggedInAccountViewModel.switch_mode()
+    assertEquals(LoggedInAccountViewModel.Mode.WORKER, loggedInAccountViewModel.mode.value)
+
+    loggedInAccountViewModel.switch_mode()
+    assertEquals(LoggedInAccountViewModel.Mode.USER, loggedInAccountViewModel.mode.value)
+
+    loggedInAccountViewModel.switch_mode()
+    assertEquals(LoggedInAccountViewModel.Mode.WORKER, loggedInAccountViewModel.mode.value)
+  }
 }


### PR DESCRIPTION
Added a stateflow called mode in the LoggedInAccountViewModel  which is User by default because when we first open the application we are in User mode. Also added a function called switch_mode() which alternates the stateflow between User and Worker, this stateflow shloud be use to change the UI based on the operating mode.