### PR TITLE
feat(search): add ServiceTypeBottomBar to SearchWorkerResult screen

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/ServiceTypeTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/ServiceTypeTest.kt
@@ -1,0 +1,117 @@
+package com.arygm.quickfix.ui.search
+
+import ServiceTypeBottomBar
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+
+class ServiceTypeTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun testTitleIsDisplayed() {
+    composeTestRule.setContent {
+      ServiceTypeBottomBar(
+          serviceTypes = listOf("Exterior Painter", "Interior Painter"),
+          selectedService = null,
+          onServiceSelected = {},
+          onApply = {},
+          onReset = {})
+    }
+
+    // Check if the title is displayed
+    composeTestRule
+        .onNodeWithTag("serviceTypeTitle")
+        .assertExists()
+        .assertTextEquals("Service type")
+  }
+
+  @Test
+  fun testServiceTypeItemsAreDisplayed() {
+    composeTestRule.setContent {
+      ServiceTypeBottomBar(
+          serviceTypes = listOf("Exterior Painter", "Interior Painter"),
+          selectedService = null,
+          onServiceSelected = {},
+          onApply = {},
+          onReset = {})
+    }
+
+    // Check if the grid is displayed
+    composeTestRule.onNodeWithTag("serviceTypeGrid").assertExists()
+
+    // Check if specific service items are displayed
+    composeTestRule
+        .onNodeWithTag("serviceTypeItem_0")
+        .assertExists()
+        .assertTextEquals("Exterior Painter")
+
+    composeTestRule
+        .onNodeWithTag("serviceTypeItem_1")
+        .assertExists()
+        .assertTextEquals("Interior Painter")
+  }
+
+  @Test
+  fun testApplyButtonClick() {
+    var isApplied = false
+
+    composeTestRule.setContent {
+      ServiceTypeBottomBar(
+          serviceTypes = listOf("Exterior Painter"),
+          selectedService = null,
+          onServiceSelected = {},
+          onApply = { isApplied = true },
+          onReset = {})
+    }
+
+    // Click the Apply button
+    composeTestRule.onNodeWithTag("applyButton").assertExists().performClick()
+
+    // Assert the Apply action is triggered
+    assert(isApplied)
+  }
+
+  @Test
+  fun testResetButtonClick() {
+    var isReset = false
+
+    composeTestRule.setContent {
+      ServiceTypeBottomBar(
+          serviceTypes = listOf("Exterior Painter"),
+          selectedService = null,
+          onServiceSelected = {},
+          onApply = {},
+          onReset = { isReset = true })
+    }
+
+    // Click the Reset button
+    composeTestRule.onNodeWithTag("resetButton").assertExists().performClick()
+
+    // Assert the Reset action is triggered
+    assert(isReset)
+  }
+
+  @Test
+  fun testSelectServiceType() {
+    var selectedService: String? = null
+
+    composeTestRule.setContent {
+      ServiceTypeBottomBar(
+          serviceTypes = listOf("Exterior Painter", "Interior Painter"),
+          selectedService = selectedService,
+          onServiceSelected = { selectedService = it },
+          onApply = {},
+          onReset = {})
+    }
+
+    // Click the first service type
+    composeTestRule.onNodeWithTag("serviceTypeItem_0").assertExists().performClick()
+
+    // Assert the correct service type was selected
+    assert(selectedService == "Exterior Painter")
+  }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/search/SearchWorkerResult.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/SearchWorkerResult.kt
@@ -1,14 +1,18 @@
 package com.arygm.quickfix.ui.search
 
+import ServiceTypeBottomBar
 import android.location.Location
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
@@ -18,13 +22,11 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.WorkspacePremium
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -38,6 +40,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -97,12 +100,12 @@ fun SearchWorkerResult(
     searchViewModel: SearchViewModel,
     accountViewModel: AccountViewModel
 ) {
-
   val searchQuery by searchViewModel.searchQuery.collectAsState()
   val workerProfiles by searchViewModel.workerProfiles.collectAsState()
   var currentLocation by remember { mutableStateOf<Location?>(null) }
-
-  var locationHelper: LocationHelper = LocationHelper(LocalContext.current, MainActivity())
+  val locationHelper: LocationHelper = LocationHelper(LocalContext.current, MainActivity())
+  var selectedService by remember { mutableStateOf<String?>(null) }
+  var isServiceTypeBottomBarVisible by remember { mutableStateOf(false) }
 
   Scaffold(
       topBar = {
@@ -125,123 +128,152 @@ fun SearchWorkerResult(
                 TopAppBarDefaults.centerAlignedTopAppBarColors(
                     containerColor = colorScheme.background),
         )
-      }) { paddingValues ->
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(paddingValues),
-            horizontalAlignment = Alignment.CenterHorizontally) {
-              Column(
-                  modifier = Modifier.fillMaxWidth(),
-                  horizontalAlignment = Alignment.CenterHorizontally,
-                  verticalArrangement = Arrangement.Top) {
-                    Text(
-                        text = searchQuery,
-                        style = poppinsTypography.labelMedium,
-                        fontSize = 24.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        textAlign = TextAlign.Center,
-                    )
-                    Text(
-                        text = "This is a sample description for the $searchQuery result",
-                        style = poppinsTypography.labelSmall,
-                        fontWeight = FontWeight.Medium,
-                        fontSize = 12.sp,
-                        color = colorScheme.onSurface,
-                        textAlign = TextAlign.Center,
-                    )
-                  }
-              LazyRow(
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .padding(top = 20.dp, bottom = 10.dp)
-                          .padding(horizontal = 10.dp)
-                          .wrapContentHeight()
-                          .testTag("filter_buttons_row"),
-                  verticalAlignment = Alignment.CenterVertically,
-              ) {
-                items(1) {
-                  Box(modifier = Modifier.height(40.dp)) {
-                    IconButton(
-                        onClick = { /* Goes to all filter screen */},
-                        modifier = Modifier.padding(bottom = 8.dp),
-                        content = {
-                          Icon(
-                              imageVector = Icons.Default.Tune,
-                              contentDescription = "Filter",
-                              tint = colorScheme.onBackground,
-                          )
+      },
+      content = { paddingValues ->
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+          Column(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(bottom = 80.dp), // Prevent content from overlapping bottom bar
+              horizontalAlignment = Alignment.CenterHorizontally) {
+                // Header Section
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Top) {
+                      Text(
+                          text = searchQuery,
+                          style = poppinsTypography.labelMedium,
+                          fontSize = 24.sp,
+                          fontWeight = FontWeight.SemiBold,
+                          textAlign = TextAlign.Center,
+                      )
+                      Text(
+                          text = "This is a sample description for the $searchQuery result",
+                          style = poppinsTypography.labelSmall,
+                          fontWeight = FontWeight.Medium,
+                          fontSize = 12.sp,
+                          color = colorScheme.onSurface,
+                          textAlign = TextAlign.Center,
+                      )
+                    }
+
+                // Filter Buttons
+                LazyRow(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(top = 20.dp, bottom = 10.dp)
+                            .padding(horizontal = 10.dp)
+                            .wrapContentHeight()
+                            .testTag("filter_buttons_row"),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                  items(listOfButtons.size) { index ->
+                    val button = listOfButtons[index]
+                    QuickFixButton(
+                        buttonText = button.text,
+                        onClickAction = {
+                          if (button.text == "Service Type") {
+                            isServiceTypeBottomBarVisible = true // Show bottom bar
+                          } else {
+                            button.onClick()
+                          }
                         },
-                        colors =
-                            IconButtonDefaults.iconButtonColors()
-                                .copy(containerColor = colorScheme.surface),
-                    )
+                        buttonColor = colorScheme.surface,
+                        textColor = colorScheme.onBackground,
+                        textStyle =
+                            poppinsTypography.labelSmall.copy(fontWeight = FontWeight.Medium),
+                        height = 40.dp,
+                        leadingIcon = button.leadingIcon,
+                        trailingIcon = button.trailingIcon,
+                        contentPadding = PaddingValues(vertical = 0.dp, horizontal = 10.dp),
+                        modifier = Modifier.testTag("filter_button_${button.text}"))
+                    Spacer(modifier = Modifier.width(10.dp))
                   }
-                  Spacer(modifier = Modifier.width(10.dp))
                 }
 
-                items(listOfButtons.size) { index ->
-                  QuickFixButton(
-                      buttonText = listOfButtons[index].text,
-                      onClickAction = listOfButtons[index].onClick,
-                      buttonColor = colorScheme.surface,
-                      textColor = colorScheme.onBackground,
-                      textStyle = poppinsTypography.labelSmall.copy(fontWeight = FontWeight.Medium),
-                      height = 40.dp,
-                      leadingIcon = listOfButtons[index].leadingIcon,
-                      trailingIcon = listOfButtons[index].trailingIcon,
-                      contentPadding = PaddingValues(vertical = 0.dp, horizontal = 10.dp),
-                      modifier = Modifier.testTag("filter_button_${listOfButtons[index].text}"))
-                  Spacer(modifier = Modifier.width(10.dp))
+                // Worker Profiles
+                LazyColumn(modifier = Modifier.fillMaxWidth().testTag("worker_profiles_list")) {
+                  items(workerProfiles.size) { index ->
+                    val profile = workerProfiles[index]
+                    var account by remember { mutableStateOf<Account?>(null) }
+                    var distance by remember { mutableStateOf<Int?>(null) }
+
+                    locationHelper.getCurrentLocation { location ->
+                      currentLocation = location
+                      location?.let {
+                        distance =
+                            profile.location
+                                ?.let { workerLocation ->
+                                  searchViewModel.calculateDistance(
+                                      workerLocation.latitude,
+                                      workerLocation.longitude,
+                                      it.latitude,
+                                      it.longitude)
+                                }
+                                ?.toInt()
+                      }
+                    }
+
+                    LaunchedEffect(profile.uid) {
+                      accountViewModel.fetchUserAccount(profile.uid) { fetchedAccount: Account? ->
+                        account = fetchedAccount
+                      }
+                    }
+
+                    account?.let { acc ->
+                      (if (profile.location?.name.isNullOrEmpty()) "Unknown"
+                          else profile.location?.name)
+                          ?.let {
+                            SearchWorkerProfileResult(
+                                modifier = Modifier.testTag("worker_profile_result$index"),
+                                profileImage = R.drawable.placeholder_worker,
+                                name = "${acc.firstName} ${acc.lastName}",
+                                category = profile.fieldOfWork,
+                                rating = profile.rating,
+                                reviewCount = profile.reviews.size,
+                                location = it,
+                                price = profile.hourlyRate?.toString() ?: "N/A",
+                                onBookClick = { /* Handle book click in preview */},
+                                distance = distance,
+                            )
+                          }
+                    }
+                    Spacer(modifier = Modifier.height(3.dp))
+                  }
                 }
               }
-              LazyColumn(modifier = Modifier.fillMaxWidth().testTag("worker_profiles_list")) {
-                items(workerProfiles.size) { index ->
-                  val profile = workerProfiles[index]
-                  var account by remember { mutableStateOf<Account?>(null) }
-                  var distance by remember { mutableStateOf<Int?>(null) }
 
-                  locationHelper.getCurrentLocation { location ->
-                    currentLocation = location
-                    location?.let {
-                      distance =
-                          profile.location
-                              ?.let { workerLocation ->
-                                searchViewModel.calculateDistance(
-                                    workerLocation.latitude,
-                                    workerLocation.longitude,
-                                    it.latitude,
-                                    it.longitude)
-                              }
-                              ?.toInt()
-                    }
-                  }
-
-                  LaunchedEffect(profile.uid) {
-                    accountViewModel.fetchUserAccount(profile.uid) { fetchedAccount: Account? ->
-                      account = fetchedAccount
-                    }
-                  }
-
-                  account?.let { acc ->
-                    (if (profile.location?.name.isNullOrEmpty()) "Unknown"
-                        else profile.location?.name)
-                        ?.let {
-                          SearchWorkerProfileResult(
-                              modifier = Modifier.testTag("worker_profile_result$index"),
-                              profileImage = R.drawable.placeholder_worker,
-                              name = "${acc.firstName} ${acc.lastName}",
-                              category = profile.fieldOfWork,
-                              rating = profile.rating,
-                              reviewCount = profile.reviews.size,
-                              location = it,
-                              price = profile.hourlyRate?.toString() ?: "N/A",
-                              onBookClick = { /* Handle book click in preview */},
-                              distance = distance,
-                          )
-                        }
-                  }
-                  Spacer(modifier = Modifier.height(3.dp))
+          // Show Bottom Bar if Visible
+          if (isServiceTypeBottomBarVisible) {
+            Box(
+                modifier =
+                    Modifier.align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .background(Color.White)
+                        .systemBarsPadding() // Ensures it overlays the bottom bar and accounts for
+                // system UI
+                ) {
+                  ServiceTypeBottomBar(
+                      serviceTypes =
+                          listOf(
+                              "Exterior Painter",
+                              "Interior Painter",
+                              "Cabinet Painter",
+                              "Wallpaper Removal",
+                              "Color Consultation"),
+                      selectedService = selectedService,
+                      onServiceSelected = { selectedService = it },
+                      onApply = {
+                        isServiceTypeBottomBarVisible = false // Hide bottom bar
+                        // Handle Apply Action
+                      },
+                      onReset = {
+                        selectedService = null
+                        isServiceTypeBottomBarVisible = false // Hide bottom bar
+                      })
                 }
-              }
-            }
-      }
+          }
+        }
+      })
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/search/ServiceType.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/ServiceType.kt
@@ -1,0 +1,136 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ServiceTypeBottomBar(
+    serviceTypes: List<String>,
+    selectedService: String?,
+    onServiceSelected: (String) -> Unit,
+    onApply: () -> Unit,
+    onReset: () -> Unit
+) {
+  Box(
+      modifier =
+          Modifier.fillMaxWidth()
+              .wrapContentHeight()
+              .background(Color.White, RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+              .padding(8.dp)
+              .testTag("serviceTypeBottomBar") // Test tag for the entire component
+      ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              // Title
+              Text(
+                  text = "Service type",
+                  fontWeight = FontWeight.Bold,
+                  fontSize = 32.sp,
+                  color = Color.Black,
+                  modifier =
+                      Modifier.padding(bottom = 8.dp)
+                          .testTag("serviceTypeTitle") // Test tag for title
+                  )
+
+              // Divider
+              HorizontalDivider(
+                  modifier =
+                      Modifier.fillMaxWidth().testTag("serviceTypeDivider"), // Test tag for divider
+                  thickness = 1.dp,
+                  color = Color(0xFFE0E0E0))
+
+              Spacer(modifier = Modifier.height(20.dp))
+
+              // Service Type Options (Wrapped in Grid)
+              LazyVerticalGrid(
+                  columns = GridCells.Adaptive(100.dp), // Adaptive cells based on available space
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .wrapContentHeight()
+                          .testTag("serviceTypeGrid"), // Test tag for grid
+                  horizontalArrangement = Arrangement.spacedBy(8.dp),
+                  verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(serviceTypes.size) { index ->
+                      val service = serviceTypes[index]
+                      Box(
+                          modifier =
+                              Modifier.background(
+                                      if (service == selectedService) Color(0xFF800000)
+                                      else Color(0xFFE0E0E0),
+                                      shape = RoundedCornerShape(100.dp))
+                                  .clickable { onServiceSelected(service) }
+                                  .padding(horizontal = 12.dp, vertical = 3.dp)
+                                  .testTag(
+                                      "serviceTypeItem_$index") // Unique test tag for each item
+                          ) {
+                            Text(
+                                text = service,
+                                color =
+                                    if (service == selectedService) Color.White else Color.Black,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1)
+                          }
+                    }
+                  }
+
+              Spacer(modifier = Modifier.height(20.dp))
+
+              Column(
+                  verticalArrangement = Arrangement.spacedBy(8.dp),
+                  horizontalAlignment = Alignment.CenterHorizontally,
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .testTag("serviceTypeButtonsColumn") // Test tag for the buttons column
+                  ) {
+                    // Apply Button
+                    Button(
+                        onClick = onApply,
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .height(36.dp)
+                                .testTag("applyButton"), // Test tag for apply button
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF800000))) {
+                          Text(text = "Apply", fontSize = 15.sp, color = Color.White)
+                        }
+
+                    // Reset Button
+                    Button(
+                        onClick = onReset,
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .height(36.dp)
+                                .testTag("resetButton"), // Test tag for reset button
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = Color.Transparent, contentColor = Color.Gray),
+                        elevation = ButtonDefaults.buttonElevation(0.dp)) {
+                          Text(text = "Reset", fontSize = 15.sp, color = Color.Gray)
+                        }
+                  }
+            }
+      }
+}


### PR DESCRIPTION
Integrated the ServiceTypeBottomBar at the bottom of the SearchWorkerResult screen. Managed state for service selection using `remember`. The bottom bar supports selecting a service type, applying the selection, and resetting it.