### PR TITLE
Add Availability Worker Filtering in SearchWorkerResult screen

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/SearchWorkerResultScreenTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/SearchWorkerResultScreenTest.kt
@@ -1,7 +1,24 @@
 package com.arygm.quickfix.ui.search
 
-import androidx.compose.ui.test.*
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.filter
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasParent
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.arygm.quickfix.model.account.Account
 import com.arygm.quickfix.model.account.AccountRepositoryFirestore

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/SearchWorkerResultScreenTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/SearchWorkerResultScreenTest.kt
@@ -12,6 +12,8 @@ import com.arygm.quickfix.model.profile.WorkerProfile
 import com.arygm.quickfix.model.profile.WorkerProfileRepositoryFirestore
 import com.arygm.quickfix.model.search.SearchViewModel
 import com.arygm.quickfix.ui.navigation.NavigationActions
+import java.time.LocalDate
+import java.time.LocalTime
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -121,14 +123,26 @@ class SearchWorkerResultScreenTest {
     composeTestRule.setContent {
       SearchWorkerResult(navigationActions, searchViewModel, accountViewModel)
     }
-    // Verify that all filter buttons in the LazyRow are visible and clickable
-    val filterButtonsRow = composeTestRule.onNodeWithTag("filter_buttons_row")
 
-    listOfButtons.forEachIndexed { index, button ->
-      // Scroll to each button and check if it's displayed with a click action
+    // Wait for the UI to settle
+    composeTestRule.waitForIdle()
+
+    // Verify that the LazyRow for filter buttons is visible
+    val filterButtonsRow = composeTestRule.onNodeWithTag("filter_buttons_row")
+    filterButtonsRow.assertExists().assertIsDisplayed()
+
+    // Define the expected button texts
+    val expectedButtons =
+        listOf("Location", "Service Type", "Availability", "Highest Rating", "Price Range")
+
+    // Verify each button exists, is displayed, and clickable
+    expectedButtons.forEachIndexed { index, buttonText ->
+      // Scroll to the button index (important for last two buttons in LazyRow)
       filterButtonsRow.performScrollToIndex(index)
+
+      // Assert button properties
       composeTestRule
-          .onNodeWithTag("filter_button_${button.text}")
+          .onNodeWithText(buttonText)
           .assertExists()
           .assertIsDisplayed()
           .assertHasClickAction()
@@ -451,5 +465,257 @@ class SearchWorkerResultScreenTest {
         .assertExists()
         .assertIsDisplayed()
         .assertTextContains("save")
+  }
+
+  @Test
+  fun testWorkerFilteringByAvailabilityDays() {
+    // Set up test worker profiles with specific working hours and unavailability
+    val worker1 =
+        WorkerProfile(
+            uid = "worker1",
+            fieldOfWork = "Painter",
+            rating = 4.5,
+            workingHours = Pair(LocalTime.of(9, 0), LocalTime.of(17, 0)),
+            unavailability_list = listOf(LocalDate.now()),
+            location = Location(0.0, 0.0))
+
+    val worker2 =
+        WorkerProfile(
+            uid = "worker2",
+            fieldOfWork = "Electrician",
+            rating = 4.0,
+            workingHours = Pair(LocalTime.of(8, 0), LocalTime.of(16, 0)),
+            unavailability_list = emptyList(),
+            location = Location(0.0, 0.0))
+
+    val worker3 =
+        WorkerProfile(
+            uid = "worker3",
+            fieldOfWork = "Plumber",
+            rating = 5.0,
+            workingHours = Pair(LocalTime.of(10, 0), LocalTime.of(18, 0)),
+            unavailability_list = emptyList(),
+            location = Location(0.0, 0.0))
+
+    // Update the searchViewModel with these test workers
+    searchViewModel._workerProfiles.value = listOf(worker1, worker2, worker3)
+
+    // Set the composable content
+    composeTestRule.setContent {
+      SearchWorkerResult(navigationActions, searchViewModel, accountViewModel)
+    }
+
+    // Initially, all workers should be displayed
+    composeTestRule.waitForIdle()
+
+    // Verify that all 3 workers are displayed
+    composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(3)
+
+    // Simulate clicking the "Availability" filter button
+    composeTestRule.onNodeWithText("Availability").performClick()
+
+    // composeTestRule.waitUntil(10000){false}
+
+    // Wait for the bottom sheet to appear
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("availabilityBottomSheet").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("timePickerColumn").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("timeInput").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomSheetColumn").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Enter time").assertIsDisplayed()
+
+    val today = LocalDate.now()
+    val todayDayOfMonth = today.dayOfMonth.toString()
+
+    val textFields =
+        composeTestRule.onAllNodes(hasSetTextAction()).filter(hasParent(hasTestTag("timeInput")))
+
+    // Ensure that we have at least two text fields
+    assert(textFields.fetchSemanticsNodes().size >= 2)
+
+    // Set the hour to "07"
+    textFields[0].performTextReplacement("10")
+
+    // Set the minute to "00"
+    textFields[1].performTextReplacement("00")
+
+    // Find the node representing today's date and perform a click
+    composeTestRule.onNode(hasText(todayDayOfMonth) and hasClickAction()).performClick()
+
+    composeTestRule.onNodeWithText("OK").performClick()
+
+    composeTestRule.waitForIdle()
+
+    // Verify that 2 workers are displayed
+    composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(2)
+  }
+
+  @Test
+  fun testWorkerFilteringByAvailabilityHours() {
+    // Set up test worker profiles with specific working hours and unavailability
+    val worker1 =
+        WorkerProfile(
+            uid = "worker1",
+            fieldOfWork = "Painter",
+            rating = 4.5,
+            workingHours = Pair(LocalTime.of(9, 0), LocalTime.of(17, 0)),
+            unavailability_list = emptyList(),
+            location = Location(0.0, 0.0))
+
+    val worker2 =
+        WorkerProfile(
+            uid = "worker2",
+            fieldOfWork = "Electrician",
+            rating = 4.0,
+            workingHours = Pair(LocalTime.of(8, 0), LocalTime.of(16, 0)),
+            unavailability_list = emptyList(),
+            location = Location(0.0, 0.0))
+
+    val worker3 =
+        WorkerProfile(
+            uid = "worker3",
+            fieldOfWork = "Plumber",
+            rating = 5.0,
+            workingHours = Pair(LocalTime.of(10, 0), LocalTime.of(18, 0)),
+            unavailability_list = emptyList(),
+            location = Location(0.0, 0.0))
+
+    // Update the searchViewModel with these test workers
+    searchViewModel._workerProfiles.value = listOf(worker1, worker2, worker3)
+
+    // Set the composable content
+    composeTestRule.setContent {
+      SearchWorkerResult(navigationActions, searchViewModel, accountViewModel)
+    }
+
+    // Initially, all workers should be displayed
+    composeTestRule.waitForIdle()
+
+    // Verify that all 3 workers are displayed
+    composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(3)
+
+    // Simulate clicking the "Availability" filter button
+    composeTestRule.onNodeWithText("Availability").performClick()
+
+    // composeTestRule.waitUntil(10000){false}
+
+    // Wait for the bottom sheet to appear
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("availabilityBottomSheet").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("timePickerColumn").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("timeInput").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomSheetColumn").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Enter time").assertIsDisplayed()
+
+    val today = LocalDate.now()
+    val todayDayOfMonth = today.dayOfMonth.toString()
+
+    val textFields =
+        composeTestRule.onAllNodes(hasSetTextAction()).filter(hasParent(hasTestTag("timeInput")))
+
+    // Ensure that we have at least two text fields
+    assert(textFields.fetchSemanticsNodes().size >= 2)
+
+    // Set the hour to "07"
+    textFields[0].performTextReplacement("08")
+
+    // Set the minute to "00"
+    textFields[1].performTextReplacement("00")
+
+    // Find the node representing today's date and perform a click
+    composeTestRule.onNode(hasText(todayDayOfMonth) and hasClickAction()).performClick()
+
+    composeTestRule.onNodeWithText("OK").performClick()
+
+    composeTestRule.waitForIdle()
+
+    // Verify that one worker is displayed
+    composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(1)
+  }
+
+  @Test
+  fun testWorkerFilteringByAvailabilityMinutes() {
+    // Set up test worker profiles with specific working hours and unavailability
+    val worker1 =
+        WorkerProfile(
+            uid = "worker1",
+            fieldOfWork = "Painter",
+            rating = 4.5,
+            workingHours = Pair(LocalTime.of(9, 0), LocalTime.of(17, 0)),
+            unavailability_list = emptyList(),
+            location = Location(0.0, 0.0))
+
+    val worker2 =
+        WorkerProfile(
+            uid = "worker2",
+            fieldOfWork = "Electrician",
+            rating = 4.0,
+            workingHours = Pair(LocalTime.of(8, 30), LocalTime.of(16, 0)),
+            unavailability_list = emptyList(),
+            location = Location(0.0, 0.0))
+
+    val worker3 =
+        WorkerProfile(
+            uid = "worker3",
+            fieldOfWork = "Plumber",
+            rating = 5.0,
+            workingHours = Pair(LocalTime.of(10, 0), LocalTime.of(18, 0)),
+            unavailability_list = emptyList(),
+            location = Location(0.0, 0.0))
+
+    // Update the searchViewModel with these test workers
+    searchViewModel._workerProfiles.value = listOf(worker1, worker2, worker3)
+
+    // Set the composable content
+    composeTestRule.setContent {
+      SearchWorkerResult(navigationActions, searchViewModel, accountViewModel)
+    }
+
+    // Initially, all workers should be displayed
+    composeTestRule.waitForIdle()
+
+    // Verify that all 3 workers are displayed
+    composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(3)
+
+    // Simulate clicking the "Availability" filter button
+    composeTestRule.onNodeWithText("Availability").performClick()
+
+    // composeTestRule.waitUntil(10000){false}
+
+    // Wait for the bottom sheet to appear
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("availabilityBottomSheet").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("timePickerColumn").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("timeInput").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomSheetColumn").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Enter time").assertIsDisplayed()
+
+    val today = LocalDate.now()
+    val todayDayOfMonth = today.dayOfMonth.toString()
+
+    val textFields =
+        composeTestRule.onAllNodes(hasSetTextAction()).filter(hasParent(hasTestTag("timeInput")))
+
+    // Ensure that we have at least two text fields
+    assert(textFields.fetchSemanticsNodes().size >= 2)
+
+    // Set the hour to "07"
+    textFields[0].performTextReplacement("08")
+
+    // Set the minute to "00"
+    textFields[1].performTextReplacement("00")
+
+    // Find the node representing today's date and perform a click
+    composeTestRule.onNode(hasText(todayDayOfMonth) and hasClickAction()).performClick()
+
+    composeTestRule.onNodeWithText("OK").performClick()
+
+    composeTestRule.waitForIdle()
+
+    // Verify that no workers are displayed
+    composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(0)
   }
 }

--- a/app/src/main/java/com/arygm/quickfix/model/profile/Profile.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/profile/Profile.kt
@@ -4,6 +4,8 @@ import com.arygm.quickfix.model.locations.Location
 import com.arygm.quickfix.model.profile.dataFields.AddOnService
 import com.arygm.quickfix.model.profile.dataFields.IncludedService
 import com.arygm.quickfix.model.profile.dataFields.Review
+import java.time.LocalDate
+import java.time.LocalTime
 
 open class Profile(
     val uid: String,
@@ -54,6 +56,8 @@ class WorkerProfile(
     val profilePicture: String = "",
     val price: Double = 130.0,
     val displayName: String = "",
+    val unavailability_list: List<LocalDate> = emptyList<LocalDate>(),
+    val workingHours: Pair<LocalTime, LocalTime> = Pair(LocalTime.now(), LocalTime.now()),
     uid: String = ""
 ) : Profile(uid, quickFixes) {
   override fun equals(other: Any?): Boolean {

--- a/app/src/main/java/com/arygm/quickfix/model/profile/Profile.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/profile/Profile.kt
@@ -58,7 +58,8 @@ class WorkerProfile(
     val displayName: String = "",
     val unavailability_list: List<LocalDate> = emptyList<LocalDate>(),
     val workingHours: Pair<LocalTime, LocalTime> = Pair(LocalTime.now(), LocalTime.now()),
-    uid: String = ""
+    uid: String = "",
+    val tags: List<String> = emptyList(),
 ) : Profile(uid, quickFixes) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/app/src/main/java/com/arygm/quickfix/model/profile/WorkerProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/profile/WorkerProfileRepositoryFirestore.kt
@@ -8,6 +8,8 @@ import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
+import java.time.LocalDate
+import java.time.LocalTime
 import kotlin.math.cos
 
 open class WorkerProfileRepositoryFirestore(private val db: FirebaseFirestore) : ProfileRepository {
@@ -108,6 +110,11 @@ open class WorkerProfileRepositoryFirestore(private val db: FirebaseFirestore) :
                 longitude = it["longitude"] as? Double ?: 0.0,
                 name = it["name"] as? String ?: "")
           }
+      val unavailability_list =
+          document.get("unavailability_list") as? List<LocalDate> ?: emptyList<LocalDate>()
+      val workingHours =
+          document.get("workingHours") as? Pair<LocalTime, LocalTime>
+              ?: Pair(LocalTime.now(), LocalTime.now())
       WorkerProfile(
           rating = rating,
           uid = uid,
@@ -115,7 +122,8 @@ open class WorkerProfileRepositoryFirestore(private val db: FirebaseFirestore) :
           description = description,
           fieldOfWork = fieldOfWork,
           location = location,
-      )
+          unavailability_list = unavailability_list,
+          workingHours = workingHours)
     } catch (e: Exception) {
       Log.e("WorkerProfileRepositoryFirestore", "Error converting document to WorkerProfile", e)
       null

--- a/app/src/main/java/com/arygm/quickfix/model/search/SearchViewModel.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/search/SearchViewModel.kt
@@ -11,6 +11,7 @@ import com.arygm.quickfix.model.profile.WorkerProfile
 import com.arygm.quickfix.model.profile.WorkerProfileRepositoryFirestore
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
+import java.time.LocalDate
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
@@ -124,5 +125,25 @@ open class SearchViewModel(
 
     val c = 2 * atan2(sqrt(a), sqrt(1 - a))
     return earthRadius * c
+  }
+
+  fun filterWorkersByAvailability(
+      workers: List<WorkerProfile>,
+      selectedDays: List<LocalDate>,
+      selectedHour: Int,
+      selectedMinute: Int
+  ): List<WorkerProfile> {
+    return workers
+        .filter { worker ->
+          val workingStart = worker.workingHours.first
+          val workingEnd = worker.workingHours.second
+
+          // Check if the selected time is within the worker's working hours
+          (selectedHour > workingStart.hour ||
+              (selectedHour == workingStart.hour && selectedMinute >= workingStart.minute)) &&
+              (selectedHour < workingEnd.hour ||
+                  (selectedHour == workingEnd.hour && selectedMinute <= workingEnd.minute))
+        }
+        .filter { worker -> selectedDays.none { day -> worker.unavailability_list.contains(day) } }
   }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/search/SearchWorkerResult.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/SearchWorkerResult.kt
@@ -75,7 +75,6 @@ import com.arygm.quickfix.MainActivity
 import com.arygm.quickfix.R
 import com.arygm.quickfix.model.account.Account
 import com.arygm.quickfix.model.account.AccountViewModel
-import com.arygm.quickfix.model.profile.WorkerProfile
 import com.arygm.quickfix.model.search.SearchViewModel
 import com.arygm.quickfix.ui.elements.QuickFixAvailabilityBottomSheet
 import com.arygm.quickfix.ui.elements.QuickFixButton
@@ -83,7 +82,6 @@ import com.arygm.quickfix.ui.elements.QuickFixSlidingWindow
 import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.theme.poppinsTypography
 import com.arygm.quickfix.utils.LocationHelper
-import java.time.LocalDate
 
 data class SearchFilterButtons(
     val onClick: () -> Unit,
@@ -365,7 +363,8 @@ fun SearchWorkerResult(
             days,
             hour,
             minute ->
-          filteredWorkerProfiles = filterWorkersByAvailability(workerProfiles, days, hour, minute)
+          filteredWorkerProfiles =
+              searchViewModel.filterWorkersByAvailability(workerProfiles, days, hour, minute)
         }
 
     if (isWindowVisible) {
@@ -684,24 +683,4 @@ fun SearchWorkerResult(
       }
     }
   }
-}
-
-fun filterWorkersByAvailability(
-    workers: List<WorkerProfile>,
-    selectedDays: List<LocalDate>,
-    selectedHour: Int,
-    selectedMinute: Int
-): List<WorkerProfile> {
-  return workers
-      .filter { worker ->
-        val workingStart = worker.workingHours.first
-        val workingEnd = worker.workingHours.second
-
-        // Check if the selected time is within the worker's working hours
-        (selectedHour > workingStart.hour ||
-            (selectedHour == workingStart.hour && selectedMinute >= workingStart.minute)) &&
-            (selectedHour < workingEnd.hour ||
-                (selectedHour == workingEnd.hour && selectedMinute <= workingEnd.minute))
-      }
-      .filter { worker -> selectedDays.none { day -> worker.unavailability_list.contains(day) } }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/search/SearchWorkerResult.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/SearchWorkerResult.kt
@@ -75,12 +75,15 @@ import com.arygm.quickfix.MainActivity
 import com.arygm.quickfix.R
 import com.arygm.quickfix.model.account.Account
 import com.arygm.quickfix.model.account.AccountViewModel
+import com.arygm.quickfix.model.profile.WorkerProfile
 import com.arygm.quickfix.model.search.SearchViewModel
+import com.arygm.quickfix.ui.elements.QuickFixAvailabilityBottomSheet
 import com.arygm.quickfix.ui.elements.QuickFixButton
 import com.arygm.quickfix.ui.elements.QuickFixSlidingWindow
 import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.theme.poppinsTypography
 import com.arygm.quickfix.utils.LocationHelper
+import java.time.LocalDate
 
 data class SearchFilterButtons(
     val onClick: () -> Unit,
@@ -89,34 +92,6 @@ data class SearchFilterButtons(
     val trailingIcon: ImageVector? = null,
 )
 
-val listOfButtons =
-    listOf(
-        SearchFilterButtons(
-            onClick = { /* Handle click */},
-            text = "Location",
-        ),
-        SearchFilterButtons(
-            onClick = { /* Handle click */},
-            text = "Service Type",
-            trailingIcon = Icons.Default.KeyboardArrowDown,
-        ),
-        SearchFilterButtons(
-            onClick = { /* Handle click */},
-            text = "Availability",
-            leadingIcon = Icons.Default.CalendarMonth,
-            trailingIcon = Icons.Default.KeyboardArrowDown,
-        ),
-        SearchFilterButtons(
-            onClick = { /* Handle click */},
-            text = "Highest Rating",
-            leadingIcon = Icons.Default.WorkspacePremium,
-        ),
-        SearchFilterButtons(
-            onClick = { /* Handle click */},
-            text = "Price Range",
-        ),
-    )
-
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun SearchWorkerResult(
@@ -124,6 +99,35 @@ fun SearchWorkerResult(
     searchViewModel: SearchViewModel,
     accountViewModel: AccountViewModel
 ) {
+  var showAvailabilityBottomSheet by remember { mutableStateOf(false) }
+
+  val listOfButtons =
+      listOf(
+          SearchFilterButtons(
+              onClick = { /* Handle click */},
+              text = "Location",
+          ),
+          SearchFilterButtons(
+              onClick = { /* Handle click */},
+              text = "Service Type",
+              trailingIcon = Icons.Default.KeyboardArrowDown,
+          ),
+          SearchFilterButtons(
+              onClick = { showAvailabilityBottomSheet = true },
+              text = "Availability",
+              leadingIcon = Icons.Default.CalendarMonth,
+              trailingIcon = Icons.Default.KeyboardArrowDown,
+          ),
+          SearchFilterButtons(
+              onClick = { /* Handle click */},
+              text = "Highest Rating",
+              leadingIcon = Icons.Default.WorkspacePremium,
+          ),
+          SearchFilterButtons(
+              onClick = { /* Handle click */},
+              text = "Price Range",
+          ),
+      )
 
   // ==========================================================================//
   // ============ TODO: REMOVE NO-DATA WHEN BACKEND IS IMPLEMENTED ============//
@@ -194,6 +198,7 @@ fun SearchWorkerResult(
   val searchQuery by searchViewModel.searchQuery.collectAsState()
   val workerProfiles by searchViewModel.workerProfiles.collectAsState()
   var currentLocation by remember { mutableStateOf<Location?>(null) }
+  var filteredWorkerProfiles by remember { mutableStateOf(workerProfiles) }
 
   val locationHelper: LocationHelper = LocationHelper(LocalContext.current, MainActivity())
 
@@ -302,8 +307,8 @@ fun SearchWorkerResult(
                 }
 
                 LazyColumn(modifier = Modifier.fillMaxWidth().testTag("worker_profiles_list")) {
-                  items(workerProfiles.size) { index ->
-                    val profile = workerProfiles[index]
+                  items(filteredWorkerProfiles.size) { index ->
+                    val profile = filteredWorkerProfiles[index]
                     var account by remember { mutableStateOf<Account?>(null) }
                     var distance by remember { mutableStateOf<Int?>(null) }
 
@@ -353,6 +358,14 @@ fun SearchWorkerResult(
                   }
                 }
               }
+        }
+
+    QuickFixAvailabilityBottomSheet(
+        showAvailabilityBottomSheet, onDismissRequest = { showAvailabilityBottomSheet = false }) {
+            days,
+            hour,
+            minute ->
+          filteredWorkerProfiles = filterWorkersByAvailability(workerProfiles, days, hour, minute)
         }
 
     if (isWindowVisible) {
@@ -671,4 +684,24 @@ fun SearchWorkerResult(
       }
     }
   }
+}
+
+fun filterWorkersByAvailability(
+    workers: List<WorkerProfile>,
+    selectedDays: List<LocalDate>,
+    selectedHour: Int,
+    selectedMinute: Int
+): List<WorkerProfile> {
+  return workers
+      .filter { worker ->
+        val workingStart = worker.workingHours.first
+        val workingEnd = worker.workingHours.second
+
+        // Check if the selected time is within the worker's working hours
+        (selectedHour > workingStart.hour ||
+            (selectedHour == workingStart.hour && selectedMinute >= workingStart.minute)) &&
+            (selectedHour < workingEnd.hour ||
+                (selectedHour == workingEnd.hour && selectedMinute <= workingEnd.minute))
+      }
+      .filter { worker -> selectedDays.none { day -> worker.unavailability_list.contains(day) } }
 }

--- a/app/src/test/java/com/arygm/quickfix/model/search/WorkerFilterTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/search/WorkerFilterTest.kt
@@ -1,0 +1,138 @@
+package com.arygm.quickfix.model.search
+
+import com.arygm.quickfix.model.profile.WorkerProfile
+import com.arygm.quickfix.ui.search.filterWorkersByAvailability
+import java.time.LocalDate
+import java.time.LocalTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WorkerFilterTest {
+
+  @Test
+  fun `worker is available within working hours and not on unavailable days`() {
+    val workers =
+        listOf(
+            WorkerProfile(
+                uid = "worker1",
+                workingHours = Pair(LocalTime.of(8, 30), LocalTime.of(17, 0)),
+                unavailability_list = listOf(LocalDate.of(2023, 12, 4))),
+            WorkerProfile(
+                uid = "worker2",
+                workingHours = Pair(LocalTime.of(9, 0), LocalTime.of(18, 0)),
+                unavailability_list = listOf(LocalDate.of(2023, 12, 5))))
+
+    val selectedDays = listOf(LocalDate.of(2023, 12, 3)) // Not on unavailable days
+    val selectedHour = 10
+    val selectedMinute = 0
+
+    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+
+    assertEquals(2, result.size)
+    assertEquals("worker1", result[0].uid)
+    assertEquals("worker2", result[1].uid)
+  }
+
+  @Test
+  fun `worker is excluded if unavailable on selected day`() {
+    val workers =
+        listOf(
+            WorkerProfile(
+                uid = "worker1",
+                workingHours = Pair(LocalTime.of(8, 30), LocalTime.of(17, 0)),
+                unavailability_list = listOf(LocalDate.of(2023, 12, 4)) // Unavailable
+                ))
+
+    val selectedDays = listOf(LocalDate.of(2023, 12, 4)) // Selected day matches unavailable day
+    val selectedHour = 10
+    val selectedMinute = 0
+
+    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+
+    assertEquals(0, result.size) // Worker should be excluded
+  }
+
+  @Test
+  fun `worker is excluded if selected time is before start time`() {
+    val workers =
+        listOf(
+            WorkerProfile(
+                uid = "worker1",
+                workingHours = Pair(LocalTime.of(9, 0), LocalTime.of(17, 0)),
+                unavailability_list = emptyList()))
+
+    val selectedDays = listOf(LocalDate.of(2023, 12, 3))
+    val selectedHour = 8
+    val selectedMinute = 30 // Before start time
+
+    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+
+    assertEquals(0, result.size) // Worker should be excluded
+  }
+
+  @Test
+  fun `worker is excluded if selected time is after end time`() {
+    val workers =
+        listOf(
+            WorkerProfile(
+                uid = "worker1",
+                workingHours = Pair(LocalTime.of(8, 30), LocalTime.of(17, 0)),
+                unavailability_list = emptyList()))
+
+    val selectedDays = listOf(LocalDate.of(2023, 12, 3))
+    val selectedHour = 17
+    val selectedMinute = 30 // After end time
+
+    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+
+    assertEquals(0, result.size) // Worker should be excluded
+  }
+
+  @Test
+  fun `worker is included if selected time is exactly start or end time`() {
+    val workers =
+        listOf(
+            WorkerProfile(
+                uid = "worker1",
+                workingHours = Pair(LocalTime.of(8, 30), LocalTime.of(17, 0)),
+                unavailability_list = emptyList()))
+
+    val selectedDays = listOf(LocalDate.of(2023, 12, 3))
+
+    // Test for start time
+    var result = filterWorkersByAvailability(workers, selectedDays, 8, 30)
+    assertEquals(1, result.size) // Worker should be included
+
+    // Test for end time
+    result = filterWorkersByAvailability(workers, selectedDays, 17, 0)
+    assertEquals(1, result.size) // Worker should be included
+  }
+
+  @Test
+  fun `multiple workers are filtered correctly`() {
+    val workers =
+        listOf(
+            WorkerProfile(
+                uid = "worker1",
+                workingHours = Pair(LocalTime.of(8, 30), LocalTime.of(17, 0)),
+                unavailability_list = emptyList()),
+            WorkerProfile(
+                uid = "worker2",
+                workingHours = Pair(LocalTime.of(9, 0), LocalTime.of(15, 0)),
+                unavailability_list = listOf(LocalDate.of(2023, 12, 4))),
+            WorkerProfile(
+                uid = "worker3",
+                workingHours = Pair(LocalTime.of(7, 0), LocalTime.of(19, 0)),
+                unavailability_list = listOf(LocalDate.of(2023, 12, 5))))
+
+    val selectedDays = listOf(LocalDate.of(2023, 12, 4)) // One worker is unavailable on this day
+    val selectedHour = 9
+    val selectedMinute = 30
+
+    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+
+    assertEquals(2, result.size) // Only two workers should be included
+    assertEquals("worker1", result[0].uid)
+    assertEquals("worker3", result[1].uid)
+  }
+}

--- a/app/src/test/java/com/arygm/quickfix/model/search/WorkerFilterTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/search/WorkerFilterTest.kt
@@ -1,13 +1,27 @@
 package com.arygm.quickfix.model.search
 
+import com.arygm.quickfix.model.category.CategoryRepositoryFirestore
 import com.arygm.quickfix.model.profile.WorkerProfile
-import com.arygm.quickfix.ui.search.filterWorkersByAvailability
+import com.arygm.quickfix.model.profile.WorkerProfileRepositoryFirestore
 import java.time.LocalDate
 import java.time.LocalTime
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.mock
 
 class WorkerFilterTest {
+
+  private lateinit var searchViewModel: SearchViewModel
+  private lateinit var workerProfileRepo: WorkerProfileRepositoryFirestore
+  private lateinit var categoryRepo: CategoryRepositoryFirestore
+
+  @Before
+  fun setup() {
+    workerProfileRepo = mock(WorkerProfileRepositoryFirestore::class.java)
+    categoryRepo = mock(CategoryRepositoryFirestore::class.java)
+    searchViewModel = SearchViewModel(workerProfileRepo, categoryRepo)
+  }
 
   @Test
   fun `worker is available within working hours and not on unavailable days`() {
@@ -26,7 +40,9 @@ class WorkerFilterTest {
     val selectedHour = 10
     val selectedMinute = 0
 
-    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+    val result =
+        searchViewModel.filterWorkersByAvailability(
+            workers, selectedDays, selectedHour, selectedMinute)
 
     assertEquals(2, result.size)
     assertEquals("worker1", result[0].uid)
@@ -47,7 +63,9 @@ class WorkerFilterTest {
     val selectedHour = 10
     val selectedMinute = 0
 
-    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+    val result =
+        searchViewModel.filterWorkersByAvailability(
+            workers, selectedDays, selectedHour, selectedMinute)
 
     assertEquals(0, result.size) // Worker should be excluded
   }
@@ -65,7 +83,9 @@ class WorkerFilterTest {
     val selectedHour = 8
     val selectedMinute = 30 // Before start time
 
-    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+    val result =
+        searchViewModel.filterWorkersByAvailability(
+            workers, selectedDays, selectedHour, selectedMinute)
 
     assertEquals(0, result.size) // Worker should be excluded
   }
@@ -83,7 +103,9 @@ class WorkerFilterTest {
     val selectedHour = 17
     val selectedMinute = 30 // After end time
 
-    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+    val result =
+        searchViewModel.filterWorkersByAvailability(
+            workers, selectedDays, selectedHour, selectedMinute)
 
     assertEquals(0, result.size) // Worker should be excluded
   }
@@ -100,11 +122,11 @@ class WorkerFilterTest {
     val selectedDays = listOf(LocalDate.of(2023, 12, 3))
 
     // Test for start time
-    var result = filterWorkersByAvailability(workers, selectedDays, 8, 30)
+    var result = searchViewModel.filterWorkersByAvailability(workers, selectedDays, 8, 30)
     assertEquals(1, result.size) // Worker should be included
 
     // Test for end time
-    result = filterWorkersByAvailability(workers, selectedDays, 17, 0)
+    result = searchViewModel.filterWorkersByAvailability(workers, selectedDays, 17, 0)
     assertEquals(1, result.size) // Worker should be included
   }
 
@@ -129,7 +151,9 @@ class WorkerFilterTest {
     val selectedHour = 9
     val selectedMinute = 30
 
-    val result = filterWorkersByAvailability(workers, selectedDays, selectedHour, selectedMinute)
+    val result =
+        searchViewModel.filterWorkersByAvailability(
+            workers, selectedDays, selectedHour, selectedMinute)
 
     assertEquals(2, result.size) // Only two workers should be included
     assertEquals("worker1", result[0].uid)

--- a/app/src/test/java/com/arygm/quickfix/model/search/WorkerFilterTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/search/WorkerFilterTest.kt
@@ -19,8 +19,7 @@ class WorkerFilterTest {
   @Before
   fun setup() {
     workerProfileRepo = mock(WorkerProfileRepositoryFirestore::class.java)
-    categoryRepo = mock(CategoryRepositoryFirestore::class.java)
-    searchViewModel = SearchViewModel(workerProfileRepo, categoryRepo)
+    searchViewModel = SearchViewModel(workerProfileRepo)
   }
 
   @Test


### PR DESCRIPTION
Added filterWorkersByAvailability function to filter workers based on:

    Working hours: Workers are excluded if the selected time is before their start time or after their end time, including minute-level precision.
    Unavailability: Workers are excluded if they are unavailable on any of the selected days.
    
And integrated it in the SearchWorkerResult screen and it's actually the onOkClick function of the QuickFixAvailabilityBottomSheet.
Tested the filtering function in some UI tests as well as some unit tests.