### PR TITLE
feat: Add tests and components for QuickFix Details and Sliding Window

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixDetailsScreenTest.kt
@@ -1,0 +1,131 @@
+package com.arygm.quickfix.ui.elements
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.arygm.quickfix.model.locations.Location
+import com.arygm.quickfix.model.profile.dataFields.Service
+import com.arygm.quickfix.model.quickfix.QuickFix
+import com.arygm.quickfix.model.quickfix.Status
+import com.google.firebase.Timestamp
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class QuickFixDetailsScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var quickFixMock: QuickFix
+
+  @Before
+  fun setup() {
+    val includedServices =
+        listOf(
+            mock(Service::class.java).apply { `when`(name).thenReturn("Initial Consultation") },
+            mock(Service::class.java).apply {
+              `when`(name).thenReturn("Basic Surface Preparation")
+            })
+
+    val addOnServices =
+        listOf(
+            mock(Service::class.java).apply {
+              `when`(name).thenReturn("Extra Coats for added Durability")
+            },
+            mock(Service::class.java).apply { `when`(name).thenReturn("Premium Paint Upgrade") })
+
+    quickFixMock =
+        QuickFix(
+            uid = "12345",
+            status = Status.PENDING,
+            imageUrl = listOf("https://via.placeholder.com/120", "https://via.placeholder.com/120"),
+            date = listOf(Timestamp.now()),
+            time = Timestamp.now(),
+            includedServices = includedServices,
+            addOnServices = addOnServices,
+            workerName = "Worker Name",
+            userName = "User Name",
+            chatUid = "chat_12345",
+            title = "This is a very long description that will be truncated in the collapsed view.",
+            bill = emptyList(),
+            location = Location(latitude = 48.8566, longitude = 2.3522, name = "Paris, France"))
+  }
+
+  @Test
+  fun quickFixDetailsScreen_displaysTitleAndServices() {
+    composeTestRule.setContent {
+      QuickFixDetailsScreen(quickFix = quickFixMock, onShowMoreToggle = {}, isExpanded = false)
+    }
+
+    // Check the title
+    composeTestRule.onNodeWithText("Selected Services").assertIsDisplayed()
+
+    // Check displayed services
+    quickFixMock.includedServices.forEach { service ->
+      composeTestRule.onNodeWithText(service.name).assertIsDisplayed()
+    }
+    quickFixMock.addOnServices.forEach { service ->
+      composeTestRule.onNodeWithText(service.name).assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun quickFixDetailsScreen_displaysDescriptionCollapsed() {
+    composeTestRule.setContent {
+      QuickFixDetailsScreen(quickFix = quickFixMock, onShowMoreToggle = {}, isExpanded = false)
+    }
+
+    // Check that the description is truncated
+    composeTestRule.onNodeWithText(quickFixMock.title.take(250) + "...").assertIsDisplayed()
+
+    // Check that "Show more" button is displayed
+    composeTestRule.onNodeWithText("Show more").assertIsDisplayed()
+  }
+
+  @Test
+  fun quickFixDetailsScreen_displaysDescriptionExpanded() {
+    composeTestRule.setContent {
+      QuickFixDetailsScreen(quickFix = quickFixMock, onShowMoreToggle = {}, isExpanded = true)
+    }
+
+    // Check that the full description is displayed
+    composeTestRule.onNodeWithText(quickFixMock.title).assertIsDisplayed()
+
+    // Check that "Show less" button is displayed
+    composeTestRule.onNodeWithText("Show less").assertIsDisplayed()
+  }
+
+  @Test
+  fun quickFixDetailsScreen_togglesDescription() {
+    // Mock pour onShowMoreToggle
+    val onShowMoreToggleMock = mock<(Boolean) -> Unit>()
+
+    composeTestRule.setContent {
+      QuickFixDetailsScreen(
+          quickFix = quickFixMock, onShowMoreToggle = onShowMoreToggleMock, isExpanded = false)
+    }
+
+    // Vérifiez que "Show more" est initialement affiché
+    composeTestRule.onNodeWithText("Show more").assertIsDisplayed()
+
+    // Simulez un clic sur "Show more"
+    composeTestRule.onNodeWithText("Show more").performClick()
+
+    // Vérifiez que onShowMoreToggle a été appelé avec true
+    verify(onShowMoreToggleMock).invoke(true)
+  }
+
+  @Test
+  fun quickFixDetailsScreen_displaysImages() {
+    composeTestRule.setContent {
+      QuickFixDetailsScreen(quickFix = quickFixMock, onShowMoreToggle = {}, isExpanded = false)
+    }
+
+    // Check placeholders for images
+    composeTestRule
+        .onAllNodesWithText("Image")
+        .assertCountEquals(2) // 2 placeholders should be displayed
+  }
+}

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixSlidingWindowContentTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixSlidingWindowContentTest.kt
@@ -1,0 +1,91 @@
+package com.arygm.quickfix.ui.elements
+
+import androidx.compose.runtime.*
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arygm.quickfix.model.locations.Location
+import com.arygm.quickfix.model.profile.dataFields.Service
+import com.arygm.quickfix.model.quickfix.QuickFix
+import com.arygm.quickfix.model.quickfix.Status
+import com.google.firebase.Timestamp
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+@RunWith(AndroidJUnit4::class)
+class QuickFixSlidingWindowContentTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private val quickFixMock =
+      QuickFix(
+          uid = "12345",
+          status = Status.PENDING,
+          imageUrl = listOf("https://via.placeholder.com/120"),
+          date = listOf(Timestamp.now()),
+          time = Timestamp.now(),
+          includedServices =
+              listOf(
+                  mock(Service::class.java).apply {
+                    `when`(name).thenReturn("Initial Consultation")
+                  },
+                  mock(Service::class.java).apply {
+                    `when`(name).thenReturn("Professional Clean-Up")
+                  }),
+          addOnServices =
+              listOf(
+                  mock(Service::class.java).apply {
+                    `when`(name).thenReturn("Premium Paint Upgrade")
+                  },
+                  mock(Service::class.java).apply {
+                    `when`(name).thenReturn("Extra Coats for added Durability")
+                  }),
+          workerName = "Worker Name",
+          userName = "User Name",
+          chatUid = "chat_12345",
+          title = "QuickFix Description",
+          bill = emptyList(),
+          location = Location(48.8566, 2.3522, "Paris, France"))
+
+  @Test
+  fun quickFixSlidingWindowContent_displaysTitle() {
+    composeTestRule.setContent {
+      QuickFixSlidingWindowContent(quickFix = quickFixMock, onDismiss = {}, isVisible = true)
+    }
+
+    composeTestRule
+        .onNodeWithText("${quickFixMock.userName}'s QuickFix request")
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun quickFixSlidingWindowContent_displaysServices() {
+    composeTestRule.setContent {
+      QuickFixSlidingWindowContent(quickFix = quickFixMock, onDismiss = {}, isVisible = true)
+    }
+
+    quickFixMock.includedServices.forEach { service ->
+      composeTestRule.onNodeWithText(service.name).assertIsDisplayed()
+    }
+    quickFixMock.addOnServices.forEach { service ->
+      composeTestRule.onNodeWithText(service.name).assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun quickFixSlidingWindowContent_displaysAppointmentDetails() {
+    composeTestRule.setContent {
+      QuickFixSlidingWindowContent(quickFix = quickFixMock, onDismiss = {}, isVisible = true)
+    }
+
+    val appointmentTime = quickFixMock.time.toDate().toString().split(" ")[3]
+    val appointmentDate = quickFixMock.time.toDate().toString().split(" ").take(3).joinToString(" ")
+
+    composeTestRule.onNodeWithText(appointmentTime).assertIsDisplayed()
+    composeTestRule.onNodeWithText(appointmentDate).assertIsDisplayed()
+    composeTestRule.onNodeWithText(quickFixMock.location.name).assertIsDisplayed()
+  }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixDetailsdescription.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixDetailsdescription.kt
@@ -1,0 +1,157 @@
+package com.arygm.quickfix.ui.elements
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.arygm.quickfix.model.quickfix.QuickFix
+import com.arygm.quickfix.ui.theme.poppinsTypography
+
+@Composable
+fun QuickFixDetailsScreen(
+    quickFix: QuickFix,
+    onShowMoreToggle: (Boolean) -> Unit,
+    isExpanded: Boolean
+) {
+  BoxWithConstraints(
+      modifier =
+          Modifier.fillMaxWidth()
+              .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(16.dp))
+              .padding(16.dp)) {
+        val screenWidth = maxWidth
+        val screenHeight = maxHeight
+
+        // Combine services logic
+        val includedServicesToShow = quickFix.includedServices.take(2)
+        val addOnServicesToShow = quickFix.addOnServices.take(2)
+
+        // If the total number of displayed services is less than 4, fill the remainder with the
+        // other list
+        val extraIncludedServices =
+            quickFix.includedServices
+                .drop(2)
+                .take(4 - includedServicesToShow.size - addOnServicesToShow.size)
+        val extraAddOnServices =
+            quickFix.addOnServices
+                .drop(2)
+                .take(4 - includedServicesToShow.size - addOnServicesToShow.size)
+
+        val allServicesToShow =
+            includedServicesToShow +
+                addOnServicesToShow +
+                extraIncludedServices +
+                extraAddOnServices
+
+        Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.Start) {
+          // Images Section
+          ImageSelector(screenWidth, screenHeight * 1.2f, quickFix)
+
+          // Selected Services
+          Spacer(modifier = Modifier.height(screenHeight * 0.02f))
+
+          Text(
+              text = "Selected Services",
+              style = poppinsTypography.headlineMedium,
+              color = MaterialTheme.colorScheme.onBackground,
+              modifier = Modifier.padding(bottom = screenHeight * 0.01f))
+
+          allServicesToShow.forEach { service ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(bottom = screenHeight * 0.01f)) {
+                  Icon(
+                      imageVector =
+                          if (quickFix.includedServices.contains(service)) Icons.Default.Check
+                          else Icons.Default.Star,
+                      contentDescription = null,
+                      tint = MaterialTheme.colorScheme.primary,
+                      modifier = Modifier.size(screenWidth * 0.05f))
+                  Spacer(modifier = Modifier.width(screenWidth * 0.02f))
+                  Text(
+                      text = service.name,
+                      style = poppinsTypography.bodyMedium,
+                      color =
+                          if (quickFix.includedServices.contains(service))
+                              MaterialTheme.colorScheme.onBackground
+                          else MaterialTheme.colorScheme.primary)
+                }
+          }
+
+          // Description Section with "Show More"
+          Spacer(modifier = Modifier.height(screenHeight * 0.02f))
+          Text(
+              text = "Description",
+              style = poppinsTypography.headlineMedium,
+              color = MaterialTheme.colorScheme.onBackground,
+              modifier = Modifier.padding(bottom = screenHeight * 0.01f))
+          Column {
+            Text(
+                text = if (isExpanded) quickFix.title else quickFix.title.take(250) + "...",
+                style = poppinsTypography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            TextButton(
+                onClick = { onShowMoreToggle(!isExpanded) },
+                modifier = Modifier.align(Alignment.CenterHorizontally)) {
+                  Text(
+                      text = if (isExpanded) "Show less" else "Show more",
+                      style = poppinsTypography.labelMedium,
+                      color = MaterialTheme.colorScheme.primary)
+                }
+          }
+        }
+      }
+}
+
+@Composable
+fun ImageSelector(screenWidth: Dp, screenHeight: Dp, quickFix: QuickFix) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .height(screenHeight * 0.23f) // Adjust height as needed
+              .clip(RoundedCornerShape(8.dp))
+              .background(MaterialTheme.colorScheme.background)
+              .padding(8.dp), // General padding for uniformity
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+      verticalAlignment = Alignment.CenterVertically) {
+        quickFix.imageUrl.take(2).forEach { imageUrl ->
+          Box(
+              modifier =
+                  Modifier.weight(1f) // Ensure equal spacing for each image
+                      .height(screenHeight * 0.20f) // Maintain a square aspect ratio
+                      .clip(RoundedCornerShape(8.dp)) // Clip corners
+                      .background(MaterialTheme.colorScheme.secondary)
+                      .padding(8.dp), // Specific padding for each image
+              contentAlignment = Alignment.Center) {
+                // Placeholder for an image. Replace with actual image loading logic using Coil or
+                // Glide
+                Text(
+                    text = "Image",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSecondary)
+              }
+        }
+      }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixSlindingWindowWithContent.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixSlindingWindowWithContent.kt
@@ -1,0 +1,280 @@
+package com.arygm.quickfix.ui.elements
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import com.arygm.quickfix.model.quickfix.QuickFix
+
+@Composable
+fun QuickFixSlidingWindowContent(
+    quickFix: QuickFix,
+    onDismiss: () -> Unit,
+    isVisible: Boolean = true
+) {
+  QuickFixSlidingWindow(isVisible = isVisible, onDismiss = onDismiss) {
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxHeight().background(MaterialTheme.colorScheme.surface)) {
+          val screenWidth = maxWidth
+          val screenHeight = maxHeight
+
+          LazyColumn(
+              modifier =
+                  Modifier.fillMaxSize()
+                      .padding(horizontal = screenWidth * 0.05f) // Relative padding
+              ) {
+                // Header with Title
+                item {
+                  Box(
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .padding(
+                                  vertical = screenHeight * 0.02f), // Relative vertical padding
+                      contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "${quickFix.userName}'s QuickFix request",
+                            style = MaterialTheme.typography.headlineSmall,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            textAlign = TextAlign.Center)
+                      }
+                }
+
+                // Spacer
+                item { Spacer(modifier = Modifier.height(screenHeight * 0.01f)) }
+
+                // Photo Description Section
+                item {
+                  Text(
+                      text = "Photo description",
+                      style = MaterialTheme.typography.bodyMedium,
+                      color = MaterialTheme.colorScheme.onBackground)
+                  Spacer(modifier = Modifier.height(screenHeight * 0.01f))
+                  ImageSelector(screenWidth, screenHeight * 0.9f, quickFix)
+                }
+
+                // Spacer
+                item { Spacer(modifier = Modifier.height(screenHeight * 0.02f)) }
+
+                // Included and Add-On Services
+                item {
+                  Text(
+                      text = "Selected services",
+                      style = MaterialTheme.typography.headlineSmall,
+                      color = MaterialTheme.colorScheme.onBackground)
+                }
+                item { Spacer(modifier = Modifier.height(screenHeight * 0.01f)) }
+
+                // Included Services
+                item {
+                  Text(
+                      text = "Included Services",
+                      style = MaterialTheme.typography.bodyMedium,
+                      color = MaterialTheme.colorScheme.onSurface)
+                }
+                items(quickFix.includedServices) { service ->
+                  Row(
+                      verticalAlignment = Alignment.CenterVertically,
+                      modifier =
+                          Modifier.padding(
+                              vertical = screenHeight * 0.005f) // Relative vertical padding
+                      ) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.size(screenWidth * 0.04f) // Relative size
+                            )
+                        Spacer(modifier = Modifier.width(screenWidth * 0.02f)) // Relative spacing
+                        Text(
+                            text = service.name,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface)
+                      }
+                }
+
+                // Spacer
+                item { Spacer(modifier = Modifier.height(screenHeight * 0.01f)) }
+
+                // Add-On Services
+                item {
+                  Text(
+                      text = "Add-on Services",
+                      style = MaterialTheme.typography.bodyMedium,
+                      color = MaterialTheme.colorScheme.primary)
+                }
+                items(quickFix.addOnServices) { service ->
+                  Row(
+                      verticalAlignment = Alignment.CenterVertically,
+                      modifier = Modifier.padding(vertical = screenHeight * 0.005f)) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(screenWidth * 0.04f))
+                        Spacer(modifier = Modifier.width(screenWidth * 0.02f))
+                        Text(
+                            text = service.name,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary)
+                      }
+                }
+
+                // Spacer
+                item { Spacer(modifier = Modifier.height(screenHeight * 0.02f)) }
+
+                // Description Section
+                item {
+                  Text(
+                      text = "Description",
+                      style = MaterialTheme.typography.headlineSmall,
+                      color = MaterialTheme.colorScheme.onBackground)
+                  Box(
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .clip(RoundedCornerShape(screenWidth * 0.02f))
+                              .background(MaterialTheme.colorScheme.background)
+                              .padding(screenWidth * 0.03f)) {
+                        Text(
+                            text = quickFix.title,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                      }
+                }
+
+                // Spacer
+                item { Spacer(modifier = Modifier.height(screenHeight * 0.02f)) }
+
+                // Appointment Details
+                item {
+                  Text(
+                      text = "Suggested appointment",
+                      style = MaterialTheme.typography.headlineSmall,
+                      color = MaterialTheme.colorScheme.onBackground)
+                  Spacer(modifier = Modifier.height(screenHeight * 0.01f))
+
+                  val appointmentTime =
+                      quickFix.time.toDate().toString().split(" ")[3] // Extracts time
+                  val appointmentDate =
+                      quickFix.time
+                          .toDate()
+                          .toString()
+                          .split(" ")
+                          .take(3)
+                          .joinToString(" ") // Extracts date
+
+                  Box(
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .clip(RoundedCornerShape(screenWidth * 0.02f))
+                              .background(MaterialTheme.colorScheme.background)
+                              .padding(screenWidth * 0.03f)) {
+                        Column {
+                          Row(
+                              modifier = Modifier.fillMaxWidth(),
+                              verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector = Icons.Default.Schedule,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurface,
+                                    modifier = Modifier.size(screenWidth * 0.04f))
+                                Spacer(modifier = Modifier.width(screenWidth * 0.02f))
+                                Text(
+                                    text = appointmentTime,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface)
+                              }
+
+                          Spacer(modifier = Modifier.height(screenHeight * 0.01f))
+
+                          Row(
+                              modifier = Modifier.fillMaxWidth(),
+                              verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector = Icons.Default.CalendarMonth,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurface,
+                                    modifier = Modifier.size(screenWidth * 0.04f))
+                                Spacer(modifier = Modifier.width(screenWidth * 0.02f))
+                                Text(
+                                    text = appointmentDate,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface)
+                              }
+
+                          Spacer(modifier = Modifier.height(screenHeight * 0.01f))
+
+                          Row(
+                              modifier = Modifier.fillMaxWidth(),
+                              verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector = Icons.Default.LocationOn,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurface,
+                                    modifier = Modifier.size(screenWidth * 0.04f))
+                                Spacer(modifier = Modifier.width(screenWidth * 0.02f))
+                                Text(
+                                    text = quickFix.location.name,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface)
+                              }
+                        }
+                      }
+                }
+
+                // Spacer
+                item { Spacer(modifier = Modifier.height(screenHeight * 0.02f)) }
+
+                // Swipe Hint
+                item {
+                  Row(
+                      modifier = Modifier.fillMaxWidth().padding(vertical = screenHeight * 0.02f),
+                      horizontalArrangement = Arrangement.Center,
+                      verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector =
+                                Icons.Default
+                                    .ArrowForward, // Replace with an appropriate swipe icon
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurface)
+                        Spacer(modifier = Modifier.width(screenWidth * 0.02f))
+                        Text(
+                            text = "Swipe right to hide QuickFix details",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface)
+                      }
+                }
+              }
+        }
+  }
+}


### PR DESCRIPTION
This pull request introduces new UI tests for QuickFix components and implements the QuickFixDetailsScreen UI in the Android project. The most important changes include the addition of test cases for QuickFixDetailsScreen and QuickFixSlidingWindowContent, and the implementation of the QuickFixDetailsScreen UI.

### Test Cases Addition:
* [`app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixDetailsScreenTest.kt`](diffhunk://#diff-66c312f025fd400dcb0c1f961f688c432e219f590fd4824904864cea63b39833R1-R161): Added new test cases to verify the display of title, services, description (both collapsed and expanded), and images in the QuickFixDetailsScreen.
* [`app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixSlidingWindowContentTest.kt`](diffhunk://#diff-f90af2665e9dd1edaeafdb06c94e8958f4c62141a5db9dc5836d2b4c2415ba11R1-R98): Added new test cases to verify the display of title, services, and appointment details in the QuickFixSlidingWindowContent.

### UI Implementation:
* [`app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixDetailsdescription.kt`](diffhunk://#diff-867ef3f5d07fba01eb682a99b2e41b5006460a3d5ef4de1028e7e9fc9ca60958R1-R228): Implemented the QuickFixDetailsScreen UI, including the layout for displaying images, services, and a description with a "Show more/less" toggle functionality.
<img width="134" alt="details" src="https://github.com/user-attachments/assets/162aa0e0-1602-47b1-8892-6ea4b1016793">


<img width="134" alt="sliding" src="https://github.com/user-attachments/assets/f16d6aeb-47dd-4ab7-a0e6-48db66cdf5ed">