### PR TITLE
[Offline Mode] - Implement helper functions to interface DataStore

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/profile/ProfileConfigurationScreenTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/profile/ProfileConfigurationScreenTest.kt
@@ -64,7 +64,7 @@ class ProfileConfigurationScreenTest {
         .thenReturn(flowOf("testValue"))
 
     // Mock specific keys explicitly
-    whenever(preferencesRepository.getPreferenceByKey(com.arygm.quickfix.utils.USER_ID_KEY))
+    whenever(preferencesRepository.getPreferenceByKey(com.arygm.quickfix.utils.UID_KEY))
         .thenReturn(flowOf("testUid"))
     whenever(preferencesRepository.getPreferenceByKey(com.arygm.quickfix.utils.FIRST_NAME_KEY))
         .thenReturn(flowOf("John"))
@@ -72,7 +72,7 @@ class ProfileConfigurationScreenTest {
         .thenReturn(flowOf("Doe"))
     whenever(preferencesRepository.getPreferenceByKey(com.arygm.quickfix.utils.EMAIL_KEY))
         .thenReturn(flowOf("john.doe@example.com"))
-    whenever(preferencesRepository.getPreferenceByKey(com.arygm.quickfix.utils.DATE_OF_BIRTH_KEY))
+    whenever(preferencesRepository.getPreferenceByKey(com.arygm.quickfix.utils.BIRTH_DATE_KEY))
         .thenReturn(flowOf("01/01/1990"))
   }
 

--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/GoogleInfoScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/GoogleInfoScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,6 +54,8 @@ import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.navigation.TopLevelDestinations
 import com.arygm.quickfix.utils.ANIMATED_BOX_ROTATION
 import com.arygm.quickfix.utils.isValidDate
+import com.arygm.quickfix.utils.loadEmail
+import com.arygm.quickfix.utils.loadUserId
 import com.arygm.quickfix.utils.setAccountPreferences
 import com.arygm.quickfix.utils.stringToTimestamp
 import com.google.firebase.Firebase
@@ -71,10 +74,13 @@ fun GoogleInfoScreen(
   var firstName by remember { mutableStateOf("") }
   var lastName by remember { mutableStateOf("") }
   var birthDate by remember { mutableStateOf("") }
-  var uid by remember { mutableStateOf("") }
-  var email by remember { mutableStateOf("") }
-  preferencesViewModel.loadPreference(key = com.arygm.quickfix.utils.UID_KEY) { uid = it ?: "" }
-  preferencesViewModel.loadPreference(key = com.arygm.quickfix.utils.EMAIL_KEY) { email = it ?: "" }
+    var email by remember { mutableStateOf("Loading...") }
+    var uid by remember { mutableStateOf("Loading...") }
+
+    LaunchedEffect(Unit) {
+        uid = loadUserId(preferencesViewModel)
+        email = loadEmail(preferencesViewModel)
+    }
 
   var birthDateError by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/GoogleInfoScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/GoogleInfoScreen.kt
@@ -73,7 +73,7 @@ fun GoogleInfoScreen(
   var birthDate by remember { mutableStateOf("") }
   var uid by remember { mutableStateOf("") }
   var email by remember { mutableStateOf("") }
-  preferencesViewModel.loadPreference(key = com.arygm.quickfix.utils.USER_ID_KEY) { uid = it ?: "" }
+  preferencesViewModel.loadPreference(key = com.arygm.quickfix.utils.UID_KEY) { uid = it ?: "" }
   preferencesViewModel.loadPreference(key = com.arygm.quickfix.utils.EMAIL_KEY) { email = it ?: "" }
 
   var birthDateError by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/GoogleInfoScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/GoogleInfoScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -74,13 +73,13 @@ fun GoogleInfoScreen(
   var firstName by remember { mutableStateOf("") }
   var lastName by remember { mutableStateOf("") }
   var birthDate by remember { mutableStateOf("") }
-    var email by remember { mutableStateOf("Loading...") }
-    var uid by remember { mutableStateOf("Loading...") }
+  var email by remember { mutableStateOf("Loading...") }
+  var uid by remember { mutableStateOf("Loading...") }
 
-    LaunchedEffect(Unit) {
-        uid = loadUserId(preferencesViewModel)
-        email = loadEmail(preferencesViewModel)
-    }
+  LaunchedEffect(Unit) {
+    uid = loadUserId(preferencesViewModel)
+    email = loadEmail(preferencesViewModel)
+  }
 
   var birthDateError by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/WelcomeScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/WelcomeScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,7 +53,6 @@ import com.arygm.quickfix.ui.navigation.TopLevelDestinations
 import com.arygm.quickfix.ui.theme.ButtonPrimary
 import com.arygm.quickfix.utils.loadIsSignIn
 import com.arygm.quickfix.utils.rememberFirebaseAuthLauncher
-import com.arygm.quickfix.utils.setSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import kotlinx.coroutines.delay
@@ -81,7 +79,7 @@ fun WelcomeScreen(
       animateDpAsState(targetValue = if (expandBox) 0.dp else (-890).dp, label = "moveBoxX")
 
   val context = LocalContext.current
-    var isSignIn by remember { mutableStateOf(false) }
+  var isSignIn by remember { mutableStateOf(false) }
   val launcher =
       rememberFirebaseAuthLauncher(
           onAuthCompleteOne = { result ->
@@ -101,15 +99,15 @@ fun WelcomeScreen(
 
   // fast forward to home screen if user is already signed in
   LaunchedEffect(Unit) {
-      isSignIn = loadIsSignIn(preferencesViewModel)
-      if (isSignIn && navigationActions.currentScreen ==
-          Screen.WELCOME
-      ) { // Ensure the value is `true` before navigating
-        Log.i("SignInScreen", "User is signed in, fast forwarding to home screen")
-        navigationActions.navigateTo(TopLevelDestinations.HOME)
-      } else {
-        Log.d("SignInScreen", "User is not signed in or preference not set")
-      }
+    isSignIn = loadIsSignIn(preferencesViewModel)
+    if (isSignIn &&
+        navigationActions.currentScreen ==
+            Screen.WELCOME) { // Ensure the value is `true` before navigating
+      Log.i("SignInScreen", "User is signed in, fast forwarding to home screen")
+      navigationActions.navigateTo(TopLevelDestinations.HOME)
+    } else {
+      Log.d("SignInScreen", "User is not signed in or preference not set")
+    }
   }
   LaunchedEffect(Unit) {
     expandBox = false // Start expanding the box

--- a/app/src/main/java/com/arygm/quickfix/ui/authentication/WelcomeScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/authentication/WelcomeScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -51,7 +52,9 @@ import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.navigation.Screen
 import com.arygm.quickfix.ui.navigation.TopLevelDestinations
 import com.arygm.quickfix.ui.theme.ButtonPrimary
+import com.arygm.quickfix.utils.loadIsSignIn
 import com.arygm.quickfix.utils.rememberFirebaseAuthLauncher
+import com.arygm.quickfix.utils.setSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import kotlinx.coroutines.delay
@@ -78,7 +81,7 @@ fun WelcomeScreen(
       animateDpAsState(targetValue = if (expandBox) 0.dp else (-890).dp, label = "moveBoxX")
 
   val context = LocalContext.current
-
+    var isSignIn by remember { mutableStateOf(false) }
   val launcher =
       rememberFirebaseAuthLauncher(
           onAuthCompleteOne = { result ->
@@ -98,16 +101,15 @@ fun WelcomeScreen(
 
   // fast forward to home screen if user is already signed in
   LaunchedEffect(Unit) {
-    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.IS_SIGN_IN_KEY) {
-      if (it == true &&
-          navigationActions.currentScreen ==
-              Screen.WELCOME) { // Ensure the value is `true` before navigating
+      isSignIn = loadIsSignIn(preferencesViewModel)
+      if (isSignIn && navigationActions.currentScreen ==
+          Screen.WELCOME
+      ) { // Ensure the value is `true` before navigating
         Log.i("SignInScreen", "User is signed in, fast forwarding to home screen")
         navigationActions.navigateTo(TopLevelDestinations.HOME)
       } else {
         Log.d("SignInScreen", "User is not signed in or preference not set")
       }
-    }
   }
   LaunchedEffect(Unit) {
     expandBox = false // Start expanding the box

--- a/app/src/main/java/com/arygm/quickfix/ui/profile/AccountConfiguration.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/profile/AccountConfiguration.kt
@@ -78,7 +78,7 @@ fun AccountConfigurationScreen(
   var birthDate by remember { mutableStateOf("") }
 
   LaunchedEffect(Unit) {
-    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.USER_ID_KEY) { value ->
+    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.UID_KEY) { value ->
       uid = value ?: "nouid"
     }
     preferencesViewModel.loadPreference(com.arygm.quickfix.utils.FIRST_NAME_KEY) { value ->
@@ -90,7 +90,7 @@ fun AccountConfigurationScreen(
     preferencesViewModel.loadPreference(com.arygm.quickfix.utils.EMAIL_KEY) { value ->
       email = value ?: "noemail"
     }
-    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.DATE_OF_BIRTH_KEY) { value ->
+    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.BIRTH_DATE_KEY) { value ->
       Log.d("AccountConfigurationScreen", "Loaded birthdate: $value")
       birthDate = value ?: "nodate"
     }

--- a/app/src/main/java/com/arygm/quickfix/ui/profile/AccountConfiguration.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/profile/AccountConfiguration.kt
@@ -1,7 +1,6 @@
 package com.arygm.quickfix.ui.profile
 
 import android.annotation.SuppressLint
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -58,6 +57,10 @@ import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.theme.poppinsTypography
 import com.arygm.quickfix.utils.isValidDate
 import com.arygm.quickfix.utils.isValidEmail
+import com.arygm.quickfix.utils.loadBirthDate
+import com.arygm.quickfix.utils.loadEmail
+import com.arygm.quickfix.utils.loadFirstName
+import com.arygm.quickfix.utils.loadLastName
 import com.arygm.quickfix.utils.setAccountPreferences
 import com.google.firebase.Timestamp
 import java.util.GregorianCalendar
@@ -71,268 +74,311 @@ fun AccountConfigurationScreen(
     preferencesViewModel: PreferencesViewModel
 ) {
 
-  var uid by remember { mutableStateOf("") }
-  var firstName by remember { mutableStateOf("") }
-  var lastName by remember { mutableStateOf("") }
-  var email by remember { mutableStateOf("") }
-  var birthDate by remember { mutableStateOf("") }
+    val uid by remember { mutableStateOf("Loading...") }
+    var firstName by remember { mutableStateOf("Loading...") }
+    var lastName by remember { mutableStateOf("Loading...") }
+    var email by remember { mutableStateOf("Loading...") }
+    var birthDate by remember { mutableStateOf("Loading...") }
 
-  LaunchedEffect(Unit) {
-    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.UID_KEY) { value ->
-      uid = value ?: "nouid"
+    LaunchedEffect(Unit) {
+        firstName = loadFirstName(preferencesViewModel)
+        lastName = loadLastName(preferencesViewModel)
+        email = loadEmail(preferencesViewModel)
+        birthDate = loadBirthDate(preferencesViewModel)
     }
-    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.FIRST_NAME_KEY) { value ->
-      firstName = value ?: "nofirstname"
-    }
-    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.LAST_NAME_KEY) { value ->
-      lastName = value ?: "nolastname"
-    }
-    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.EMAIL_KEY) { value ->
-      email = value ?: "noemail"
-    }
-    preferencesViewModel.loadPreference(com.arygm.quickfix.utils.BIRTH_DATE_KEY) { value ->
-      Log.d("AccountConfigurationScreen", "Loaded birthdate: $value")
-      birthDate = value ?: "nodate"
-    }
-  }
-  var emailError by remember { mutableStateOf(false) }
-  var birthDateError by remember { mutableStateOf(false) }
 
-  val context = LocalContext.current
 
-  Scaffold(
-      containerColor = colorScheme.background,
-      topBar = {
-        TopAppBar(
-            title = {
-              Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text(
-                    "Account configuration",
-                    modifier = Modifier.testTag("AccountConfigurationTitle").padding(end = 29.dp),
-                    style = poppinsTypography.headlineMedium,
-                    color = colorScheme.primary)
-              }
-            },
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigationActions.goBack() },
-                  modifier = Modifier.testTag("goBackButton")) {
-                    Icon(
-                        Icons.AutoMirrored.Outlined.ArrowBack,
-                        contentDescription = "Back",
-                        tint = colorScheme.primary)
-                  }
-            },
-            colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
-            modifier = Modifier.testTag("AccountConfigurationTopAppBar"))
-      },
-      content = { padding ->
-        Column(
-            modifier = Modifier.fillMaxSize().fillMaxWidth().padding(padding),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally) {
-              // Account Image Placeholder
-              Icon(
-                  imageVector = Icons.Default.AccountCircle,
-                  contentDescription = "Account Circle Icon",
-                  tint = colorScheme.surface,
-                  modifier =
-                      Modifier.size(100.dp)
-                          .clip(CircleShape)
-                          .border(2.dp, colorScheme.background, CircleShape)
-                          .testTag("AccountImage"))
+    var emailError by remember { mutableStateOf(false) }
+    var birthDateError by remember { mutableStateOf(false) }
 
-              Spacer(modifier = Modifier.height(16.dp))
+    val context = LocalContext.current
 
-              // Account Card
-              Card(
-                  modifier =
-                      Modifier.fillMaxWidth(0.85f)
-                          .align(Alignment.CenterHorizontally)
-                          .testTag("AccountCard"),
-                  shape = RoundedCornerShape(16.dp),
-                  colors =
-                      CardDefaults.cardColors(
-                          containerColor = colorScheme.surface,
-                          contentColor = colorScheme.onSurface),
-                  elevation = CardDefaults.cardElevation(4.dp)) {
+    Scaffold(
+        containerColor = colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            "Account configuration",
+                            modifier = Modifier
+                                .testTag("AccountConfigurationTitle")
+                                .padding(end = 29.dp),
+                            style = poppinsTypography.headlineMedium,
+                            color = colorScheme.primary
+                        )
+                    }
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { navigationActions.goBack() },
+                        modifier = Modifier.testTag("goBackButton")
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Outlined.ArrowBack,
+                            contentDescription = "Back",
+                            tint = colorScheme.primary
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
+                modifier = Modifier.testTag("AccountConfigurationTopAppBar")
+            )
+        },
+        content = { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .fillMaxWidth()
+                    .padding(padding),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                // Account Image Placeholder
+                Icon(
+                    imageVector = Icons.Default.AccountCircle,
+                    contentDescription = "Account Circle Icon",
+                    tint = colorScheme.surface,
+                    modifier =
+                    Modifier
+                        .size(100.dp)
+                        .clip(CircleShape)
+                        .border(2.dp, colorScheme.background, CircleShape)
+                        .testTag("AccountImage")
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Account Card
+                Card(
+                    modifier =
+                    Modifier
+                        .fillMaxWidth(0.85f)
+                        .align(Alignment.CenterHorizontally)
+                        .testTag("AccountCard"),
+                    shape = RoundedCornerShape(16.dp),
+                    colors =
+                    CardDefaults.cardColors(
+                        containerColor = colorScheme.surface,
+                        contentColor = colorScheme.onSurface
+                    ),
+                    elevation = CardDefaults.cardElevation(4.dp)
+                ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(7.dp)) {
-                          Icon(
-                              painter = painterResource(R.drawable.profilevector),
-                              contentDescription = "Account Icon",
-                              tint = colorScheme.primary,
-                              modifier = Modifier.size(24.dp))
-                          Spacer(modifier = Modifier.width(65.dp))
+                        modifier = Modifier.padding(7.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.profilevector),
+                            contentDescription = "Account Icon",
+                            tint = colorScheme.primary,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(65.dp))
 
-                          val displayName = capitalizeName(firstName, lastName)
+                        val displayName = capitalizeName(firstName, lastName)
 
-                          Text(
-                              text = displayName,
-                              style = MaterialTheme.typography.bodyLarge,
-                              color = colorScheme.onBackground,
-                              modifier = Modifier.testTag("AccountName"))
-                        }
-                  }
+                        Text(
+                            text = displayName,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = colorScheme.onBackground,
+                            modifier = Modifier.testTag("AccountName")
+                        )
+                    }
+                }
 
-              Spacer(modifier = Modifier.height(60.dp))
+                Spacer(modifier = Modifier.height(60.dp))
 
-              Column(
-                  modifier =
-                      Modifier.align(Alignment.CenterHorizontally)
-                          .padding(16.dp)
-                          .zIndex(100f), // Ensure it's on top
-                  horizontalAlignment = Alignment.CenterHorizontally,
-                  verticalArrangement = Arrangement.Center) {
+                Column(
+                    modifier =
+                    Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(16.dp)
+                        .zIndex(100f), // Ensure it's on top
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
                     Row(
-                        modifier = Modifier.fillMaxWidth().height(55.dp).padding(start = 8.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(55.dp)
+                            .padding(start = 8.dp),
                         horizontalArrangement = Arrangement.SpaceEvenly,
-                        verticalAlignment = Alignment.CenterVertically) {
-                          CustomTextField(
-                              value = firstName,
-                              onValueChange = { firstName = it },
-                              placeHolderText = "First Name",
-                              placeHolderColor = colorScheme.onSecondaryContainer,
-                              label = "First Name",
-                              columnModifier = Modifier.weight(1f),
-                              modifier = Modifier.testTag("firstNameInput"))
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        CustomTextField(
+                            value = firstName,
+                            onValueChange = { firstName = it },
+                            placeHolderText = "First Name",
+                            placeHolderColor = colorScheme.onSecondaryContainer,
+                            label = "First Name",
+                            columnModifier = Modifier.weight(1f),
+                            modifier = Modifier.testTag("firstNameInput")
+                        )
 
-                          CustomTextField(
-                              value = lastName,
-                              onValueChange = { lastName = it },
-                              placeHolderText = "Last Name",
-                              placeHolderColor = colorScheme.onSecondaryContainer,
-                              label = "Last Name",
-                              columnModifier = Modifier.weight(1f),
-                              modifier = Modifier.testTag("lastNameInput"))
-                        }
-
-                    Spacer(modifier = Modifier.padding(6.dp))
-
-                    Column(modifier = Modifier.fillMaxWidth().padding(start = 8.dp)) {
-                      QuickFixTextFieldCustom(
-                          value = email,
-                          onValueChange = {
-                            email = it
-                            emailError = !isValidEmail(it)
-                            accountViewModel.accountExists(email) { exists, account ->
-                              emailError = exists && account != null && email != account.email
-                            }
-                          },
-                          placeHolderText = "Enter your email address",
-                          placeHolderColor = colorScheme.onSecondaryContainer,
-                          isError = emailError,
-                          showError = emailError,
-                          errorText = "INVALID EMAIL",
-                          modifier = Modifier.testTag("emailInput"),
-                          showLabel = true,
-                          label = {
-                            Text(
-                                "Email",
-                                style = MaterialTheme.typography.headlineSmall,
-                                color = colorScheme.onBackground,
-                                modifier = Modifier.padding(start = 3.dp).testTag("emailLabel"))
-                          })
+                        CustomTextField(
+                            value = lastName,
+                            onValueChange = { lastName = it },
+                            placeHolderText = "Last Name",
+                            placeHolderColor = colorScheme.onSecondaryContainer,
+                            label = "Last Name",
+                            columnModifier = Modifier.weight(1f),
+                            modifier = Modifier.testTag("lastNameInput")
+                        )
                     }
 
                     Spacer(modifier = Modifier.padding(6.dp))
 
-                    Column(modifier = Modifier.fillMaxWidth().padding(start = 8.dp)) {
-                      QuickFixTextFieldCustom(
-                          modifier = Modifier.testTag("birthDateInput"),
-                          value = birthDate,
-                          onValueChange = {
-                            birthDate = it
-                            birthDateError = !isValidDate(it)
-                          },
-                          placeHolderText = "Enter your birthdate (DD/MM/YYYY)",
-                          placeHolderColor = colorScheme.onSecondaryContainer,
-                          isError = birthDateError,
-                          errorText = "INVALID DATE",
-                          showError = birthDateError,
-                          showLabel = true,
-                          label = {
-                            Text(
-                                "Birthdate",
-                                style = MaterialTheme.typography.headlineSmall,
-                                color = colorScheme.onBackground,
-                                modifier = Modifier.padding(start = 3.dp).testTag("birthDateLabel"))
-                          })
+                    Column(modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 8.dp)) {
+                        QuickFixTextFieldCustom(
+                            value = email,
+                            onValueChange = {
+                                email = it
+                                emailError = !isValidEmail(it)
+                                accountViewModel.accountExists(email) { exists, account ->
+                                    emailError = exists && account != null && email != account.email
+                                }
+                            },
+                            placeHolderText = "Enter your email address",
+                            placeHolderColor = colorScheme.onSecondaryContainer,
+                            isError = emailError,
+                            showError = emailError,
+                            errorText = "INVALID EMAIL",
+                            modifier = Modifier.testTag("emailInput"),
+                            showLabel = true,
+                            label = {
+                                Text(
+                                    "Email",
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    color = colorScheme.onBackground,
+                                    modifier = Modifier
+                                        .padding(start = 3.dp)
+                                        .testTag("emailLabel")
+                                )
+                            })
                     }
-                  }
 
-              Spacer(modifier = Modifier.height(16.dp))
+                    Spacer(modifier = Modifier.padding(6.dp))
 
-              // Change password button
-              Button(
-                  onClick = { /* Handle change password */},
-                  modifier =
-                      Modifier.fillMaxWidth(0.8f)
-                          .padding(horizontal = 16.dp)
-                          .testTag("ChangePasswordButton"),
-                  colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)) {
+                    Column(modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 8.dp)) {
+                        QuickFixTextFieldCustom(
+                            modifier = Modifier.testTag("birthDateInput"),
+                            value = birthDate,
+                            onValueChange = {
+                                birthDate = it
+                                birthDateError = !isValidDate(it)
+                            },
+                            placeHolderText = "Enter your birthdate (DD/MM/YYYY)",
+                            placeHolderColor = colorScheme.onSecondaryContainer,
+                            isError = birthDateError,
+                            errorText = "INVALID DATE",
+                            showError = birthDateError,
+                            showLabel = true,
+                            label = {
+                                Text(
+                                    "Birthdate",
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    color = colorScheme.onBackground,
+                                    modifier = Modifier
+                                        .padding(start = 3.dp)
+                                        .testTag("birthDateLabel")
+                                )
+                            })
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Change password button
+                Button(
+                    onClick = { /* Handle change password */ },
+                    modifier =
+                    Modifier
+                        .fillMaxWidth(0.8f)
+                        .padding(horizontal = 16.dp)
+                        .testTag("ChangePasswordButton"),
+                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
+                ) {
                     Icon(Icons.Outlined.Lock, contentDescription = null)
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = "Change password",
                         color = colorScheme.onPrimary,
                         style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.testTag("ChangePasswordText"))
-                  }
+                        modifier = Modifier.testTag("ChangePasswordText")
+                    )
+                }
 
-              Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(8.dp))
 
-              // Save button
-              Button(
-                  onClick = {
-                    val calendar = GregorianCalendar()
-                    val parts = birthDate.split("/")
-                    if (parts.size == 3) {
-                      try {
-                        calendar.set(
-                            parts[2].toInt(),
-                            parts[1].toInt() - 1, // Months are 0-based indexed
-                            parts[0].toInt(),
-                            0,
-                            0,
-                            0)
-                        val newAccount =
-                            Account(
-                                uid = uid,
-                                firstName = firstName,
-                                lastName = lastName,
-                                email = email,
-                                birthDate = Timestamp(calendar.time))
-                        accountViewModel.updateAccount(
-                            newAccount,
-                            onSuccess = { setAccountPreferences(preferencesViewModel, newAccount) },
-                            onFailure = {})
-                        navigationActions.goBack()
-                        return@Button
-                      } catch (_: NumberFormatException) {}
-                    }
+                // Save button
+                Button(
+                    onClick = {
+                        val calendar = GregorianCalendar()
+                        val parts = birthDate.split("/")
+                        if (parts.size == 3) {
+                            try {
+                                calendar.set(
+                                    parts[2].toInt(),
+                                    parts[1].toInt() - 1, // Months are 0-based indexed
+                                    parts[0].toInt(),
+                                    0,
+                                    0,
+                                    0
+                                )
+                                val newAccount =
+                                    Account(
+                                        uid = uid,
+                                        firstName = firstName,
+                                        lastName = lastName,
+                                        email = email,
+                                        birthDate = Timestamp(calendar.time)
+                                    )
+                                accountViewModel.updateAccount(
+                                    newAccount,
+                                    onSuccess = {
+                                        setAccountPreferences(
+                                            preferencesViewModel,
+                                            newAccount
+                                        )
+                                    },
+                                    onFailure = {})
+                                navigationActions.goBack()
+                                return@Button
+                            } catch (_: NumberFormatException) {
+                            }
+                        }
 
-                    Toast.makeText(
-                            context, "Invalid format, date must be DD/MM/YYYY.", Toast.LENGTH_SHORT)
-                        .show()
-                  },
-                  enabled = !emailError && !birthDateError,
-                  modifier =
-                      Modifier.fillMaxWidth(0.8f).padding(horizontal = 16.dp).testTag("SaveButton"),
-                  colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)) {
+                        Toast.makeText(
+                            context, "Invalid format, date must be DD/MM/YYYY.", Toast.LENGTH_SHORT
+                        )
+                            .show()
+                    },
+                    enabled = !emailError && !birthDateError,
+                    modifier =
+                    Modifier
+                        .fillMaxWidth(0.8f)
+                        .padding(horizontal = 16.dp)
+                        .testTag("SaveButton"),
+                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
+                ) {
                     Text(
                         text = "Save",
                         color = colorScheme.onPrimary,
                         style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.testTag("SaveButtonText"))
-                  }
+                        modifier = Modifier.testTag("SaveButtonText")
+                    )
+                }
             }
-      })
+        })
 }
 
 private fun capitalizeName(firstName: String?, lastName: String?): String {
-  val capitalizedFirstName = firstName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
-  val capitalizedLastName = lastName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
-  return "$capitalizedFirstName $capitalizedLastName".trim()
+    val capitalizedFirstName = firstName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
+    val capitalizedLastName = lastName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
+    return "$capitalizedFirstName $capitalizedLastName".trim()
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/profile/AccountConfiguration.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/profile/AccountConfiguration.kt
@@ -74,311 +74,257 @@ fun AccountConfigurationScreen(
     preferencesViewModel: PreferencesViewModel
 ) {
 
-    val uid by remember { mutableStateOf("Loading...") }
-    var firstName by remember { mutableStateOf("Loading...") }
-    var lastName by remember { mutableStateOf("Loading...") }
-    var email by remember { mutableStateOf("Loading...") }
-    var birthDate by remember { mutableStateOf("Loading...") }
+  val uid by remember { mutableStateOf("Loading...") }
+  var firstName by remember { mutableStateOf("Loading...") }
+  var lastName by remember { mutableStateOf("Loading...") }
+  var email by remember { mutableStateOf("Loading...") }
+  var birthDate by remember { mutableStateOf("Loading...") }
 
-    LaunchedEffect(Unit) {
-        firstName = loadFirstName(preferencesViewModel)
-        lastName = loadLastName(preferencesViewModel)
-        email = loadEmail(preferencesViewModel)
-        birthDate = loadBirthDate(preferencesViewModel)
-    }
+  LaunchedEffect(Unit) {
+    firstName = loadFirstName(preferencesViewModel)
+    lastName = loadLastName(preferencesViewModel)
+    email = loadEmail(preferencesViewModel)
+    birthDate = loadBirthDate(preferencesViewModel)
+  }
 
+  var emailError by remember { mutableStateOf(false) }
+  var birthDateError by remember { mutableStateOf(false) }
 
-    var emailError by remember { mutableStateOf(false) }
-    var birthDateError by remember { mutableStateOf(false) }
+  val context = LocalContext.current
 
-    val context = LocalContext.current
+  Scaffold(
+      containerColor = colorScheme.background,
+      topBar = {
+        TopAppBar(
+            title = {
+              Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    "Account configuration",
+                    modifier = Modifier.testTag("AccountConfigurationTitle").padding(end = 29.dp),
+                    style = poppinsTypography.headlineMedium,
+                    color = colorScheme.primary)
+              }
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("goBackButton")) {
+                    Icon(
+                        Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = "Back",
+                        tint = colorScheme.primary)
+                  }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
+            modifier = Modifier.testTag("AccountConfigurationTopAppBar"))
+      },
+      content = { padding ->
+        Column(
+            modifier = Modifier.fillMaxSize().fillMaxWidth().padding(padding),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              // Account Image Placeholder
+              Icon(
+                  imageVector = Icons.Default.AccountCircle,
+                  contentDescription = "Account Circle Icon",
+                  tint = colorScheme.surface,
+                  modifier =
+                      Modifier.size(100.dp)
+                          .clip(CircleShape)
+                          .border(2.dp, colorScheme.background, CircleShape)
+                          .testTag("AccountImage"))
 
-    Scaffold(
-        containerColor = colorScheme.background,
-        topBar = {
-            TopAppBar(
-                title = {
-                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text(
-                            "Account configuration",
-                            modifier = Modifier
-                                .testTag("AccountConfigurationTitle")
-                                .padding(end = 29.dp),
-                            style = poppinsTypography.headlineMedium,
-                            color = colorScheme.primary
-                        )
-                    }
-                },
-                navigationIcon = {
-                    IconButton(
-                        onClick = { navigationActions.goBack() },
-                        modifier = Modifier.testTag("goBackButton")
-                    ) {
-                        Icon(
-                            Icons.AutoMirrored.Outlined.ArrowBack,
-                            contentDescription = "Back",
-                            tint = colorScheme.primary
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
-                modifier = Modifier.testTag("AccountConfigurationTopAppBar")
-            )
-        },
-        content = { padding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .fillMaxWidth()
-                    .padding(padding),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                // Account Image Placeholder
-                Icon(
-                    imageVector = Icons.Default.AccountCircle,
-                    contentDescription = "Account Circle Icon",
-                    tint = colorScheme.surface,
-                    modifier =
-                    Modifier
-                        .size(100.dp)
-                        .clip(CircleShape)
-                        .border(2.dp, colorScheme.background, CircleShape)
-                        .testTag("AccountImage")
-                )
+              Spacer(modifier = Modifier.height(16.dp))
 
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Account Card
-                Card(
-                    modifier =
-                    Modifier
-                        .fillMaxWidth(0.85f)
-                        .align(Alignment.CenterHorizontally)
-                        .testTag("AccountCard"),
-                    shape = RoundedCornerShape(16.dp),
-                    colors =
-                    CardDefaults.cardColors(
-                        containerColor = colorScheme.surface,
-                        contentColor = colorScheme.onSurface
-                    ),
-                    elevation = CardDefaults.cardElevation(4.dp)
-                ) {
+              // Account Card
+              Card(
+                  modifier =
+                      Modifier.fillMaxWidth(0.85f)
+                          .align(Alignment.CenterHorizontally)
+                          .testTag("AccountCard"),
+                  shape = RoundedCornerShape(16.dp),
+                  colors =
+                      CardDefaults.cardColors(
+                          containerColor = colorScheme.surface,
+                          contentColor = colorScheme.onSurface),
+                  elevation = CardDefaults.cardElevation(4.dp)) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(7.dp)
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.profilevector),
-                            contentDescription = "Account Icon",
-                            tint = colorScheme.primary,
-                            modifier = Modifier.size(24.dp)
-                        )
-                        Spacer(modifier = Modifier.width(65.dp))
+                        modifier = Modifier.padding(7.dp)) {
+                          Icon(
+                              painter = painterResource(R.drawable.profilevector),
+                              contentDescription = "Account Icon",
+                              tint = colorScheme.primary,
+                              modifier = Modifier.size(24.dp))
+                          Spacer(modifier = Modifier.width(65.dp))
 
-                        val displayName = capitalizeName(firstName, lastName)
+                          val displayName = capitalizeName(firstName, lastName)
 
-                        Text(
-                            text = displayName,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = colorScheme.onBackground,
-                            modifier = Modifier.testTag("AccountName")
-                        )
-                    }
-                }
+                          Text(
+                              text = displayName,
+                              style = MaterialTheme.typography.bodyLarge,
+                              color = colorScheme.onBackground,
+                              modifier = Modifier.testTag("AccountName"))
+                        }
+                  }
 
-                Spacer(modifier = Modifier.height(60.dp))
+              Spacer(modifier = Modifier.height(60.dp))
 
-                Column(
-                    modifier =
-                    Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .padding(16.dp)
-                        .zIndex(100f), // Ensure it's on top
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
-                ) {
+              Column(
+                  modifier =
+                      Modifier.align(Alignment.CenterHorizontally)
+                          .padding(16.dp)
+                          .zIndex(100f), // Ensure it's on top
+                  horizontalAlignment = Alignment.CenterHorizontally,
+                  verticalArrangement = Arrangement.Center) {
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(55.dp)
-                            .padding(start = 8.dp),
+                        modifier = Modifier.fillMaxWidth().height(55.dp).padding(start = 8.dp),
                         horizontalArrangement = Arrangement.SpaceEvenly,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        CustomTextField(
-                            value = firstName,
-                            onValueChange = { firstName = it },
-                            placeHolderText = "First Name",
-                            placeHolderColor = colorScheme.onSecondaryContainer,
-                            label = "First Name",
-                            columnModifier = Modifier.weight(1f),
-                            modifier = Modifier.testTag("firstNameInput")
-                        )
+                        verticalAlignment = Alignment.CenterVertically) {
+                          CustomTextField(
+                              value = firstName,
+                              onValueChange = { firstName = it },
+                              placeHolderText = "First Name",
+                              placeHolderColor = colorScheme.onSecondaryContainer,
+                              label = "First Name",
+                              columnModifier = Modifier.weight(1f),
+                              modifier = Modifier.testTag("firstNameInput"))
 
-                        CustomTextField(
-                            value = lastName,
-                            onValueChange = { lastName = it },
-                            placeHolderText = "Last Name",
-                            placeHolderColor = colorScheme.onSecondaryContainer,
-                            label = "Last Name",
-                            columnModifier = Modifier.weight(1f),
-                            modifier = Modifier.testTag("lastNameInput")
-                        )
+                          CustomTextField(
+                              value = lastName,
+                              onValueChange = { lastName = it },
+                              placeHolderText = "Last Name",
+                              placeHolderColor = colorScheme.onSecondaryContainer,
+                              label = "Last Name",
+                              columnModifier = Modifier.weight(1f),
+                              modifier = Modifier.testTag("lastNameInput"))
+                        }
+
+                    Spacer(modifier = Modifier.padding(6.dp))
+
+                    Column(modifier = Modifier.fillMaxWidth().padding(start = 8.dp)) {
+                      QuickFixTextFieldCustom(
+                          value = email,
+                          onValueChange = {
+                            email = it
+                            emailError = !isValidEmail(it)
+                            accountViewModel.accountExists(email) { exists, account ->
+                              emailError = exists && account != null && email != account.email
+                            }
+                          },
+                          placeHolderText = "Enter your email address",
+                          placeHolderColor = colorScheme.onSecondaryContainer,
+                          isError = emailError,
+                          showError = emailError,
+                          errorText = "INVALID EMAIL",
+                          modifier = Modifier.testTag("emailInput"),
+                          showLabel = true,
+                          label = {
+                            Text(
+                                "Email",
+                                style = MaterialTheme.typography.headlineSmall,
+                                color = colorScheme.onBackground,
+                                modifier = Modifier.padding(start = 3.dp).testTag("emailLabel"))
+                          })
                     }
 
                     Spacer(modifier = Modifier.padding(6.dp))
 
-                    Column(modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 8.dp)) {
-                        QuickFixTextFieldCustom(
-                            value = email,
-                            onValueChange = {
-                                email = it
-                                emailError = !isValidEmail(it)
-                                accountViewModel.accountExists(email) { exists, account ->
-                                    emailError = exists && account != null && email != account.email
-                                }
-                            },
-                            placeHolderText = "Enter your email address",
-                            placeHolderColor = colorScheme.onSecondaryContainer,
-                            isError = emailError,
-                            showError = emailError,
-                            errorText = "INVALID EMAIL",
-                            modifier = Modifier.testTag("emailInput"),
-                            showLabel = true,
-                            label = {
-                                Text(
-                                    "Email",
-                                    style = MaterialTheme.typography.headlineSmall,
-                                    color = colorScheme.onBackground,
-                                    modifier = Modifier
-                                        .padding(start = 3.dp)
-                                        .testTag("emailLabel")
-                                )
-                            })
+                    Column(modifier = Modifier.fillMaxWidth().padding(start = 8.dp)) {
+                      QuickFixTextFieldCustom(
+                          modifier = Modifier.testTag("birthDateInput"),
+                          value = birthDate,
+                          onValueChange = {
+                            birthDate = it
+                            birthDateError = !isValidDate(it)
+                          },
+                          placeHolderText = "Enter your birthdate (DD/MM/YYYY)",
+                          placeHolderColor = colorScheme.onSecondaryContainer,
+                          isError = birthDateError,
+                          errorText = "INVALID DATE",
+                          showError = birthDateError,
+                          showLabel = true,
+                          label = {
+                            Text(
+                                "Birthdate",
+                                style = MaterialTheme.typography.headlineSmall,
+                                color = colorScheme.onBackground,
+                                modifier = Modifier.padding(start = 3.dp).testTag("birthDateLabel"))
+                          })
                     }
+                  }
 
-                    Spacer(modifier = Modifier.padding(6.dp))
+              Spacer(modifier = Modifier.height(16.dp))
 
-                    Column(modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 8.dp)) {
-                        QuickFixTextFieldCustom(
-                            modifier = Modifier.testTag("birthDateInput"),
-                            value = birthDate,
-                            onValueChange = {
-                                birthDate = it
-                                birthDateError = !isValidDate(it)
-                            },
-                            placeHolderText = "Enter your birthdate (DD/MM/YYYY)",
-                            placeHolderColor = colorScheme.onSecondaryContainer,
-                            isError = birthDateError,
-                            errorText = "INVALID DATE",
-                            showError = birthDateError,
-                            showLabel = true,
-                            label = {
-                                Text(
-                                    "Birthdate",
-                                    style = MaterialTheme.typography.headlineSmall,
-                                    color = colorScheme.onBackground,
-                                    modifier = Modifier
-                                        .padding(start = 3.dp)
-                                        .testTag("birthDateLabel")
-                                )
-                            })
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Change password button
-                Button(
-                    onClick = { /* Handle change password */ },
-                    modifier =
-                    Modifier
-                        .fillMaxWidth(0.8f)
-                        .padding(horizontal = 16.dp)
-                        .testTag("ChangePasswordButton"),
-                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
-                ) {
+              // Change password button
+              Button(
+                  onClick = { /* Handle change password */},
+                  modifier =
+                      Modifier.fillMaxWidth(0.8f)
+                          .padding(horizontal = 16.dp)
+                          .testTag("ChangePasswordButton"),
+                  colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)) {
                     Icon(Icons.Outlined.Lock, contentDescription = null)
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = "Change password",
                         color = colorScheme.onPrimary,
                         style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.testTag("ChangePasswordText")
-                    )
-                }
+                        modifier = Modifier.testTag("ChangePasswordText"))
+                  }
 
-                Spacer(modifier = Modifier.height(8.dp))
+              Spacer(modifier = Modifier.height(8.dp))
 
-                // Save button
-                Button(
-                    onClick = {
-                        val calendar = GregorianCalendar()
-                        val parts = birthDate.split("/")
-                        if (parts.size == 3) {
-                            try {
-                                calendar.set(
-                                    parts[2].toInt(),
-                                    parts[1].toInt() - 1, // Months are 0-based indexed
-                                    parts[0].toInt(),
-                                    0,
-                                    0,
-                                    0
-                                )
-                                val newAccount =
-                                    Account(
-                                        uid = uid,
-                                        firstName = firstName,
-                                        lastName = lastName,
-                                        email = email,
-                                        birthDate = Timestamp(calendar.time)
-                                    )
-                                accountViewModel.updateAccount(
-                                    newAccount,
-                                    onSuccess = {
-                                        setAccountPreferences(
-                                            preferencesViewModel,
-                                            newAccount
-                                        )
-                                    },
-                                    onFailure = {})
-                                navigationActions.goBack()
-                                return@Button
-                            } catch (_: NumberFormatException) {
-                            }
-                        }
+              // Save button
+              Button(
+                  onClick = {
+                    val calendar = GregorianCalendar()
+                    val parts = birthDate.split("/")
+                    if (parts.size == 3) {
+                      try {
+                        calendar.set(
+                            parts[2].toInt(),
+                            parts[1].toInt() - 1, // Months are 0-based indexed
+                            parts[0].toInt(),
+                            0,
+                            0,
+                            0)
+                        val newAccount =
+                            Account(
+                                uid = uid,
+                                firstName = firstName,
+                                lastName = lastName,
+                                email = email,
+                                birthDate = Timestamp(calendar.time))
+                        accountViewModel.updateAccount(
+                            newAccount,
+                            onSuccess = { setAccountPreferences(preferencesViewModel, newAccount) },
+                            onFailure = {})
+                        navigationActions.goBack()
+                        return@Button
+                      } catch (_: NumberFormatException) {}
+                    }
 
-                        Toast.makeText(
-                            context, "Invalid format, date must be DD/MM/YYYY.", Toast.LENGTH_SHORT
-                        )
-                            .show()
-                    },
-                    enabled = !emailError && !birthDateError,
-                    modifier =
-                    Modifier
-                        .fillMaxWidth(0.8f)
-                        .padding(horizontal = 16.dp)
-                        .testTag("SaveButton"),
-                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
-                ) {
+                    Toast.makeText(
+                            context, "Invalid format, date must be DD/MM/YYYY.", Toast.LENGTH_SHORT)
+                        .show()
+                  },
+                  enabled = !emailError && !birthDateError,
+                  modifier =
+                      Modifier.fillMaxWidth(0.8f).padding(horizontal = 16.dp).testTag("SaveButton"),
+                  colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)) {
                     Text(
                         text = "Save",
                         color = colorScheme.onPrimary,
                         style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.testTag("SaveButtonText")
-                    )
-                }
+                        modifier = Modifier.testTag("SaveButtonText"))
+                  }
             }
-        })
+      })
 }
 
 private fun capitalizeName(firstName: String?, lastName: String?): String {
-    val capitalizedFirstName = firstName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
-    val capitalizedLastName = lastName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
-    return "$capitalizedFirstName $capitalizedLastName".trim()
+  val capitalizedFirstName = firstName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
+  val capitalizedLastName = lastName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
+  return "$capitalizedFirstName $capitalizedLastName".trim()
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/profile/ProfileScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,13 +47,8 @@ import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.navigation.Screen
 import com.arygm.quickfix.ui.navigation.TopLevelDestinations
 import com.arygm.quickfix.utils.clearAccountPreferences
-import com.arygm.quickfix.utils.loadFirstName
-import com.arygm.quickfix.utils.loadLastName
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -64,320 +58,257 @@ fun ProfileScreen(
     preferencesViewModel: PreferencesViewModel
 ) {
 
-    // List of options handled by the profile screen
-    val options =
-        listOf(
-            OptionItem("Settings", IconType.Vector(Icons.Outlined.Settings)) {},
-            OptionItem("Activity", IconType.Resource(R.drawable.dashboardvector)) {},
-            OptionItem("Set up your business account", IconType.Resource(R.drawable.workvector)) {
-                navigationActions.navigateTo(Screen.TO_WORKER)
-            },
-            OptionItem(
-                "Account configuration",
-                IconType.Resource(R.drawable.accountsettingsvector)
-            ) {
-                navigationActions.navigateTo(Screen.ACCOUNT_CONFIGURATION)
-            },
-            OptionItem("Workers network", IconType.Vector(Icons.Outlined.Phone)) {},
-            OptionItem("Legal", IconType.Vector(Icons.Outlined.Info)) {})
+  // List of options handled by the profile screen
+  val options =
+      listOf(
+          OptionItem("Settings", IconType.Vector(Icons.Outlined.Settings)) {},
+          OptionItem("Activity", IconType.Resource(R.drawable.dashboardvector)) {},
+          OptionItem("Set up your business account", IconType.Resource(R.drawable.workvector)) {
+            navigationActions.navigateTo(Screen.TO_WORKER)
+          },
+          OptionItem("Account configuration", IconType.Resource(R.drawable.accountsettingsvector)) {
+            navigationActions.navigateTo(Screen.ACCOUNT_CONFIGURATION)
+          },
+          OptionItem("Workers network", IconType.Vector(Icons.Outlined.Phone)) {},
+          OptionItem("Legal", IconType.Vector(Icons.Outlined.Info)) {})
 
-    Scaffold(
-        containerColor = colorScheme.background,
-        topBar = {
-            TopAppBar(
-                title = {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp)
-                            .testTag("ProfileTopAppBar")
-                    ) {
-                        // "Profile" Title
-                        Text(
-                            text = "Profile",
-                            color = colorScheme.primary,
-                            style = MaterialTheme.typography.headlineLarge,
-                            modifier = Modifier
-                                .padding(bottom = 8.dp)
-                                .testTag("ProfileTitle")
-                        )
+  Scaffold(
+      containerColor = colorScheme.background,
+      topBar = {
+        TopAppBar(
+            title = {
+              Column(modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("ProfileTopAppBar")) {
+                // "Profile" Title
+                Text(
+                    text = "Profile",
+                    color = colorScheme.primary,
+                    style = MaterialTheme.typography.headlineLarge,
+                    modifier = Modifier.padding(bottom = 8.dp).testTag("ProfileTitle"))
 
-                        // Profile Card
-                        Card(
-                            modifier =
-                            Modifier
-                                .fillMaxWidth(0.85f)
-                                .align(Alignment.CenterHorizontally)
-                                .testTag("ProfileCard"),
-                            shape = RoundedCornerShape(16.dp),
-                            colors =
-                            CardDefaults.cardColors(
-                                containerColor = colorScheme.surface,
-                                contentColor = colorScheme.onSurface
-                            ),
-                            elevation = CardDefaults.cardElevation(4.dp)
-                        ) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.padding(7.dp)
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.profilevector),
-                                    contentDescription = "Profile Icon",
-                                    tint = colorScheme.primary,
-                                    modifier = Modifier.size(24.dp)
-                                )
-                                Spacer(modifier = Modifier.width(65.dp))
-
-                                val displayName = remember { mutableStateOf("Loading...") }
-
-                                LaunchedEffect(Unit) {
-                                    preferencesViewModel.loadPreference(
-                                        key = com.arygm.quickfix.utils.FIRST_NAME_KEY) { firstName ->
-                                        Log.d("user", "First name: $firstName")
-                                        preferencesViewModel.loadPreference(
-                                            key = com.arygm.quickfix.utils.LAST_NAME_KEY) { lastName ->
-                                            Log.d("user", "Last name: $lastName")
-                                            displayName.value = capitalizeName(firstName, lastName)
-                                        }
-                                    }
-                                }
-                                Text(
-                                    text = displayName.value,
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    color = colorScheme.onBackground,
-                                    modifier = Modifier.testTag("ProfileName")
-                                )
-                            }
-                        }
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
-                modifier = Modifier.height(110.dp)
-            )
-        },
-        content = { padding ->
-            Column(
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        top = padding.calculateTopPadding(),
-                        bottom = padding.calculateBottomPadding()
-                    )
-                    .padding(horizontal = 16.dp)
-                    .verticalScroll(rememberScrollState())
-                    .testTag("ProfileContent")
-            ) {
-                Column(modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 0.dp)) {
-                    // Upcoming Activities Placeholder
-                    Card(
-                        modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp)
-                            .testTag("UpcomingActivitiesCard"),
-                        shape = RoundedCornerShape(8.dp),
-                        colors =
+                // Profile Card
+                Card(
+                    modifier =
+                        Modifier.fillMaxWidth(0.85f)
+                            .align(Alignment.CenterHorizontally)
+                            .testTag("ProfileCard"),
+                    shape = RoundedCornerShape(16.dp),
+                    colors =
                         CardDefaults.cardColors(
                             containerColor = colorScheme.surface,
-                            contentColor = colorScheme.onBackground
-                        ),
-                        elevation = CardDefaults.cardElevation(4.dp)
-                    ) {
-                        Text(
-                            text =
-                            "This isn’t developed yet; but it can display upcoming activities for both a user and worker",
-                            modifier = Modifier
-                                .padding(16.dp)
-                                .testTag("UpcomingActivitiesText"),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
+                            contentColor = colorScheme.onSurface),
+                    elevation = CardDefaults.cardElevation(4.dp)) {
+                      Row(
+                          verticalAlignment = Alignment.CenterVertically,
+                          modifier = Modifier.padding(7.dp)) {
+                            Icon(
+                                painter = painterResource(R.drawable.profilevector),
+                                contentDescription = "Profile Icon",
+                                tint = colorScheme.primary,
+                                modifier = Modifier.size(24.dp))
+                            Spacer(modifier = Modifier.width(65.dp))
+
+                            val displayName = remember { mutableStateOf("Loading...") }
+
+                            LaunchedEffect(Unit) {
+                              preferencesViewModel.loadPreference(
+                                  key = com.arygm.quickfix.utils.FIRST_NAME_KEY) { firstName ->
+                                    Log.d("user", "First name: $firstName")
+                                    preferencesViewModel.loadPreference(
+                                        key = com.arygm.quickfix.utils.LAST_NAME_KEY) { lastName ->
+                                          Log.d("user", "Last name: $lastName")
+                                          displayName.value = capitalizeName(firstName, lastName)
+                                        }
+                                  }
+                            }
+                            Text(
+                                text = displayName.value,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = colorScheme.onBackground,
+                                modifier = Modifier.testTag("ProfileName"))
+                          }
+                    }
+              }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
+            modifier = Modifier.height(110.dp))
+      },
+      content = { padding ->
+        Column(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(
+                        top = padding.calculateTopPadding(),
+                        bottom = padding.calculateBottomPadding())
+                    .padding(horizontal = 16.dp)
+                    .verticalScroll(rememberScrollState())
+                    .testTag("ProfileContent")) {
+              Column(modifier = Modifier.fillMaxWidth().padding(bottom = 0.dp)) {
+                // Upcoming Activities Placeholder
+                Card(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .testTag("UpcomingActivitiesCard"),
+                    shape = RoundedCornerShape(8.dp),
+                    colors =
+                        CardDefaults.cardColors(
+                            containerColor = colorScheme.surface,
+                            contentColor = colorScheme.onBackground),
+                    elevation = CardDefaults.cardElevation(4.dp)) {
+                      Text(
+                          text =
+                              "This isn’t developed yet; but it can display upcoming activities for both a user and worker",
+                          modifier = Modifier.padding(16.dp).testTag("UpcomingActivitiesText"),
+                          style = MaterialTheme.typography.bodyMedium)
                     }
 
-                    // Wallet and Help Row
-                    Row(
-                        modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp)
-                            .testTag("WalletHelpRow"),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Button(
-                            onClick = { /* Wallet click action */ },
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(80.dp)
-                                .testTag("WalletButton"),
-                            colors =
-                            ButtonDefaults.buttonColors(containerColor = colorScheme.surface),
-                            shape = RoundedCornerShape(8.dp),
-                            elevation = ButtonDefaults.buttonElevation(4.dp)
-                        ) {
+                // Wallet and Help Row
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("WalletHelpRow"),
+                    horizontalArrangement = Arrangement.SpaceBetween) {
+                      Button(
+                          onClick = { /* Wallet click action */},
+                          modifier = Modifier.weight(1f).height(80.dp).testTag("WalletButton"),
+                          colors =
+                              ButtonDefaults.buttonColors(containerColor = colorScheme.surface),
+                          shape = RoundedCornerShape(8.dp),
+                          elevation = ButtonDefaults.buttonElevation(4.dp)) {
                             Column(
                                 horizontalAlignment = Alignment.Start,
                                 verticalArrangement = Arrangement.Center,
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                modifier = Modifier.fillMaxWidth()) {
+                                  Row(verticalAlignment = Alignment.CenterVertically) {
                                     Icon(
                                         painter = painterResource(R.drawable.wallletvector),
                                         contentDescription = "Wallet Icon",
                                         modifier = Modifier.size(30.dp),
-                                        tint = colorScheme.primary
-                                    )
+                                        tint = colorScheme.primary)
                                     Spacer(modifier = Modifier.width(35.dp))
                                     Column {
-                                        Text(
-                                            text = "Wallet",
-                                            color = colorScheme.onBackground,
-                                            style = MaterialTheme.typography.bodyLarge,
-                                            modifier = Modifier.testTag("WalletText")
-                                        )
-                                        Text(
-                                            text = "___ CHF",
-                                            color = colorScheme.onBackground,
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            modifier = Modifier.testTag("WalletAmountText")
-                                        )
+                                      Text(
+                                          text = "Wallet",
+                                          color = colorScheme.onBackground,
+                                          style = MaterialTheme.typography.bodyLarge,
+                                          modifier = Modifier.testTag("WalletText"))
+                                      Text(
+                                          text = "___ CHF",
+                                          color = colorScheme.onBackground,
+                                          style = MaterialTheme.typography.bodyMedium,
+                                          modifier = Modifier.testTag("WalletAmountText"))
                                     }
+                                  }
                                 }
-                            }
-                        }
+                          }
 
-                        Spacer(modifier = Modifier.width(16.dp))
+                      Spacer(modifier = Modifier.width(16.dp))
 
-                        // Help Button
-                        Button(
-                            onClick = { /* Help click action */ },
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(80.dp)
-                                .testTag("HelpButton"),
-                            colors =
-                            ButtonDefaults.buttonColors(containerColor = colorScheme.surface),
-                            shape = RoundedCornerShape(8.dp),
-                            elevation = ButtonDefaults.buttonElevation(4.dp)
-                        ) {
+                      // Help Button
+                      Button(
+                          onClick = { /* Help click action */},
+                          modifier = Modifier.weight(1f).height(80.dp).testTag("HelpButton"),
+                          colors =
+                              ButtonDefaults.buttonColors(containerColor = colorScheme.surface),
+                          shape = RoundedCornerShape(8.dp),
+                          elevation = ButtonDefaults.buttonElevation(4.dp)) {
                             Column(
                                 horizontalAlignment = Alignment.Start,
                                 verticalArrangement = Arrangement.Center,
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                modifier = Modifier.fillMaxWidth()) {
+                                  Row(verticalAlignment = Alignment.CenterVertically) {
                                     Icon(
                                         painter = painterResource(R.drawable.helpvector),
                                         contentDescription = "Help Icon",
                                         modifier = Modifier.size(30.dp),
-                                        tint = colorScheme.primary
-                                    )
+                                        tint = colorScheme.primary)
                                     Spacer(modifier = Modifier.width(35.dp))
                                     Text(
                                         text = "Help",
                                         color = colorScheme.onBackground,
                                         style = MaterialTheme.typography.bodyLarge,
-                                        modifier = Modifier.testTag("HelpText")
-                                    )
+                                        modifier = Modifier.testTag("HelpText"))
+                                  }
                                 }
-                            }
-                        }
+                          }
                     }
-                }
+              }
 
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    options.forEach { option ->
-                        Card(
-                            modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .height(65.dp)
-                                .padding(vertical = 4.dp)
-                                .testTag(option.label.replace(" ", "") + "Option"),
-                            shape = RoundedCornerShape(8.dp),
-                            colors =
-                            CardDefaults.cardColors(
-                                containerColor = colorScheme.surface,
-                                contentColor = colorScheme.onBackground
-                            ),
-                            elevation = CardDefaults.cardElevation(4.dp),
-                            onClick = option.onClick
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(16.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                when (val icon = option.icon) {
-                                    is IconType.Resource -> {
-                                        Icon(
-                                            painter = painterResource(icon.resId),
-                                            contentDescription = "${option.label} Icon",
-                                            modifier = Modifier.size(24.dp),
-                                            tint = colorScheme.primary
-                                        )
-                                    }
-
-                                    is IconType.Vector -> {
-                                        Icon(
-                                            imageVector = icon.imageVector,
-                                            contentDescription = "${option.label} Icon",
-                                            modifier = Modifier.size(24.dp),
-                                            tint = colorScheme.primary
-                                        )
-                                    }
+              Column(modifier = Modifier.fillMaxWidth()) {
+                options.forEach { option ->
+                  Card(
+                      modifier =
+                          Modifier.fillMaxWidth()
+                              .height(65.dp)
+                              .padding(vertical = 4.dp)
+                              .testTag(option.label.replace(" ", "") + "Option"),
+                      shape = RoundedCornerShape(8.dp),
+                      colors =
+                          CardDefaults.cardColors(
+                              containerColor = colorScheme.surface,
+                              contentColor = colorScheme.onBackground),
+                      elevation = CardDefaults.cardElevation(4.dp),
+                      onClick = option.onClick) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically) {
+                              when (val icon = option.icon) {
+                                is IconType.Resource -> {
+                                  Icon(
+                                      painter = painterResource(icon.resId),
+                                      contentDescription = "${option.label} Icon",
+                                      modifier = Modifier.size(24.dp),
+                                      tint = colorScheme.primary)
                                 }
-                                Spacer(modifier = Modifier.width(16.dp))
-                                Text(
-                                    text = option.label,
-                                    style = MaterialTheme.typography.titleSmall,
-                                    modifier =
-                                    Modifier.testTag(option.label.replace(" ", "") + "Text")
-                                )
+                                is IconType.Vector -> {
+                                  Icon(
+                                      imageVector = icon.imageVector,
+                                      contentDescription = "${option.label} Icon",
+                                      modifier = Modifier.size(24.dp),
+                                      tint = colorScheme.primary)
+                                }
+                              }
+                              Spacer(modifier = Modifier.width(16.dp))
+                              Text(
+                                  text = option.label,
+                                  style = MaterialTheme.typography.titleSmall,
+                                  modifier =
+                                      Modifier.testTag(option.label.replace(" ", "") + "Text"))
                             }
-                        }
-                    }
+                      }
                 }
+              }
 
-                // Logout Button
-                Button(
-                    onClick = {
-                        clearAccountPreferences(preferencesViewModel)
-                        navigationActionsRoot.navigateTo(TopLevelDestinations.WELCOME)
-                        Log.d("user", Firebase.auth.currentUser.toString())
-                    },
-                    modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 16.dp)
-                        .testTag("LogoutButton"),
-                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
-                ) {
+              // Logout Button
+              Button(
+                  onClick = {
+                    clearAccountPreferences(preferencesViewModel)
+                    navigationActionsRoot.navigateTo(TopLevelDestinations.WELCOME)
+                    Log.d("user", Firebase.auth.currentUser.toString())
+                  },
+                  modifier =
+                      Modifier.fillMaxWidth().padding(vertical = 16.dp).testTag("LogoutButton"),
+                  colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)) {
                     Text(
                         text = "Log out",
                         color = colorScheme.onPrimary,
                         style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.testTag("LogoutText")
-                    )
-                }
+                        modifier = Modifier.testTag("LogoutText"))
+                  }
             }
-        },
-    )
+      },
+  )
 }
 
 sealed class IconType {
-    data class Resource(val resId: Int) : IconType()
+  data class Resource(val resId: Int) : IconType()
 
-    data class Vector(val imageVector: ImageVector) : IconType()
+  data class Vector(val imageVector: ImageVector) : IconType()
 }
 
 data class OptionItem(val label: String, val icon: IconType, val onClick: () -> Unit)
 
 private fun capitalizeName(firstName: String?, lastName: String?): String {
-    val capitalizedFirstName = firstName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
-    val capitalizedLastName = lastName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
-    return "$capitalizedFirstName $capitalizedLastName".trim()
+  val capitalizedFirstName = firstName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
+  val capitalizedLastName = lastName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
+  return "$capitalizedFirstName $capitalizedLastName".trim()
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/profile/ProfileScreen.kt
@@ -31,8 +31,11 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -44,6 +47,9 @@ import com.arygm.quickfix.model.offline.small.PreferencesViewModel
 import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.navigation.Screen
 import com.arygm.quickfix.ui.navigation.TopLevelDestinations
+import com.arygm.quickfix.utils.clearAccountPreferences
+import com.arygm.quickfix.utils.loadFirstName
+import com.arygm.quickfix.utils.loadLastName
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import kotlinx.coroutines.CoroutineScope
@@ -57,261 +63,321 @@ fun ProfileScreen(
     navigationActionsRoot: NavigationActions,
     preferencesViewModel: PreferencesViewModel
 ) {
-  // List of options handled by the profile screen
-  val options =
-      listOf(
-          OptionItem("Settings", IconType.Vector(Icons.Outlined.Settings)) {},
-          OptionItem("Activity", IconType.Resource(R.drawable.dashboardvector)) {},
-          OptionItem("Set up your business account", IconType.Resource(R.drawable.workvector)) {
-            navigationActions.navigateTo(Screen.TO_WORKER)
-          },
-          OptionItem("Account configuration", IconType.Resource(R.drawable.accountsettingsvector)) {
-            navigationActions.navigateTo(Screen.ACCOUNT_CONFIGURATION)
-          },
-          OptionItem("Workers network", IconType.Vector(Icons.Outlined.Phone)) {},
-          OptionItem("Legal", IconType.Vector(Icons.Outlined.Info)) {})
 
-  Scaffold(
-      containerColor = colorScheme.background,
-      topBar = {
-        TopAppBar(
-            title = {
-              Column(modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("ProfileTopAppBar")) {
-                // "Profile" Title
-                Text(
-                    text = "Profile",
-                    color = colorScheme.primary,
-                    style = MaterialTheme.typography.headlineLarge,
-                    modifier = Modifier.padding(bottom = 8.dp).testTag("ProfileTitle"))
-
-                // Profile Card
-                Card(
-                    modifier =
-                        Modifier.fillMaxWidth(0.85f)
-                            .align(Alignment.CenterHorizontally)
-                            .testTag("ProfileCard"),
-                    shape = RoundedCornerShape(16.dp),
-                    colors =
-                        CardDefaults.cardColors(
-                            containerColor = colorScheme.surface,
-                            contentColor = colorScheme.onSurface),
-                    elevation = CardDefaults.cardElevation(4.dp)) {
-                      Row(
-                          verticalAlignment = Alignment.CenterVertically,
-                          modifier = Modifier.padding(7.dp)) {
-                            Icon(
-                                painter = painterResource(R.drawable.profilevector),
-                                contentDescription = "Profile Icon",
-                                tint = colorScheme.primary,
-                                modifier = Modifier.size(24.dp))
-                            Spacer(modifier = Modifier.width(65.dp))
-                            val displayName = remember { mutableStateOf("Loading...") }
-
-                            LaunchedEffect(Unit) {
-                              preferencesViewModel.loadPreference(
-                                  key = com.arygm.quickfix.utils.FIRST_NAME_KEY) { firstName ->
-                                    Log.d("user", "First name: $firstName")
-                                    preferencesViewModel.loadPreference(
-                                        key = com.arygm.quickfix.utils.LAST_NAME_KEY) { lastName ->
-                                          Log.d("user", "Last name: $lastName")
-                                          displayName.value = capitalizeName(firstName, lastName)
-                                        }
-                                  }
-                            }
-
-                            Log.d("user", "Display name: $displayName")
-
-                            Text(
-                                text = displayName.value,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = colorScheme.onBackground,
-                                modifier = Modifier.testTag("ProfileName"))
-                          }
-                    }
-              }
+    // List of options handled by the profile screen
+    val options =
+        listOf(
+            OptionItem("Settings", IconType.Vector(Icons.Outlined.Settings)) {},
+            OptionItem("Activity", IconType.Resource(R.drawable.dashboardvector)) {},
+            OptionItem("Set up your business account", IconType.Resource(R.drawable.workvector)) {
+                navigationActions.navigateTo(Screen.TO_WORKER)
             },
-            colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
-            modifier = Modifier.height(110.dp))
-      },
-      content = { padding ->
-        Column(
-            modifier =
-                Modifier.fillMaxWidth()
+            OptionItem(
+                "Account configuration",
+                IconType.Resource(R.drawable.accountsettingsvector)
+            ) {
+                navigationActions.navigateTo(Screen.ACCOUNT_CONFIGURATION)
+            },
+            OptionItem("Workers network", IconType.Vector(Icons.Outlined.Phone)) {},
+            OptionItem("Legal", IconType.Vector(Icons.Outlined.Info)) {})
+
+    Scaffold(
+        containerColor = colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp)
+                            .testTag("ProfileTopAppBar")
+                    ) {
+                        // "Profile" Title
+                        Text(
+                            text = "Profile",
+                            color = colorScheme.primary,
+                            style = MaterialTheme.typography.headlineLarge,
+                            modifier = Modifier
+                                .padding(bottom = 8.dp)
+                                .testTag("ProfileTitle")
+                        )
+
+                        // Profile Card
+                        Card(
+                            modifier =
+                            Modifier
+                                .fillMaxWidth(0.85f)
+                                .align(Alignment.CenterHorizontally)
+                                .testTag("ProfileCard"),
+                            shape = RoundedCornerShape(16.dp),
+                            colors =
+                            CardDefaults.cardColors(
+                                containerColor = colorScheme.surface,
+                                contentColor = colorScheme.onSurface
+                            ),
+                            elevation = CardDefaults.cardElevation(4.dp)
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.padding(7.dp)
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.profilevector),
+                                    contentDescription = "Profile Icon",
+                                    tint = colorScheme.primary,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                                Spacer(modifier = Modifier.width(65.dp))
+
+                                val displayName = remember { mutableStateOf("Loading...") }
+
+                                LaunchedEffect(Unit) {
+                                    preferencesViewModel.loadPreference(
+                                        key = com.arygm.quickfix.utils.FIRST_NAME_KEY) { firstName ->
+                                        Log.d("user", "First name: $firstName")
+                                        preferencesViewModel.loadPreference(
+                                            key = com.arygm.quickfix.utils.LAST_NAME_KEY) { lastName ->
+                                            Log.d("user", "Last name: $lastName")
+                                            displayName.value = capitalizeName(firstName, lastName)
+                                        }
+                                    }
+                                }
+                                Text(
+                                    text = displayName.value,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = colorScheme.onBackground,
+                                    modifier = Modifier.testTag("ProfileName")
+                                )
+                            }
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
+                modifier = Modifier.height(110.dp)
+            )
+        },
+        content = { padding ->
+            Column(
+                modifier =
+                Modifier
+                    .fillMaxWidth()
                     .padding(
                         top = padding.calculateTopPadding(),
-                        bottom = padding.calculateBottomPadding())
+                        bottom = padding.calculateBottomPadding()
+                    )
                     .padding(horizontal = 16.dp)
                     .verticalScroll(rememberScrollState())
-                    .testTag("ProfileContent")) {
-              Column(modifier = Modifier.fillMaxWidth().padding(bottom = 0.dp)) {
-                // Upcoming Activities Placeholder
-                Card(
-                    modifier =
-                        Modifier.fillMaxWidth()
+                    .testTag("ProfileContent")
+            ) {
+                Column(modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 0.dp)) {
+                    // Upcoming Activities Placeholder
+                    Card(
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
                             .padding(vertical = 8.dp)
                             .testTag("UpcomingActivitiesCard"),
-                    shape = RoundedCornerShape(8.dp),
-                    colors =
+                        shape = RoundedCornerShape(8.dp),
+                        colors =
                         CardDefaults.cardColors(
                             containerColor = colorScheme.surface,
-                            contentColor = colorScheme.onBackground),
-                    elevation = CardDefaults.cardElevation(4.dp)) {
-                      Text(
-                          text =
-                              "This isn’t developed yet; but it can display upcoming activities for both a user and worker",
-                          modifier = Modifier.padding(16.dp).testTag("UpcomingActivitiesText"),
-                          style = MaterialTheme.typography.bodyMedium)
+                            contentColor = colorScheme.onBackground
+                        ),
+                        elevation = CardDefaults.cardElevation(4.dp)
+                    ) {
+                        Text(
+                            text =
+                            "This isn’t developed yet; but it can display upcoming activities for both a user and worker",
+                            modifier = Modifier
+                                .padding(16.dp)
+                                .testTag("UpcomingActivitiesText"),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
                     }
 
-                // Wallet and Help Row
-                Row(
-                    modifier =
-                        Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("WalletHelpRow"),
-                    horizontalArrangement = Arrangement.SpaceBetween) {
-                      Button(
-                          onClick = { /* Wallet click action */},
-                          modifier = Modifier.weight(1f).height(80.dp).testTag("WalletButton"),
-                          colors =
-                              ButtonDefaults.buttonColors(containerColor = colorScheme.surface),
-                          shape = RoundedCornerShape(8.dp),
-                          elevation = ButtonDefaults.buttonElevation(4.dp)) {
+                    // Wallet and Help Row
+                    Row(
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .testTag("WalletHelpRow"),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Button(
+                            onClick = { /* Wallet click action */ },
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(80.dp)
+                                .testTag("WalletButton"),
+                            colors =
+                            ButtonDefaults.buttonColors(containerColor = colorScheme.surface),
+                            shape = RoundedCornerShape(8.dp),
+                            elevation = ButtonDefaults.buttonElevation(4.dp)
+                        ) {
                             Column(
                                 horizontalAlignment = Alignment.Start,
                                 verticalArrangement = Arrangement.Center,
-                                modifier = Modifier.fillMaxWidth()) {
-                                  Row(verticalAlignment = Alignment.CenterVertically) {
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
                                     Icon(
                                         painter = painterResource(R.drawable.wallletvector),
                                         contentDescription = "Wallet Icon",
                                         modifier = Modifier.size(30.dp),
-                                        tint = colorScheme.primary)
+                                        tint = colorScheme.primary
+                                    )
                                     Spacer(modifier = Modifier.width(35.dp))
                                     Column {
-                                      Text(
-                                          text = "Wallet",
-                                          color = colorScheme.onBackground,
-                                          style = MaterialTheme.typography.bodyLarge,
-                                          modifier = Modifier.testTag("WalletText"))
-                                      Text(
-                                          text = "___ CHF",
-                                          color = colorScheme.onBackground,
-                                          style = MaterialTheme.typography.bodyMedium,
-                                          modifier = Modifier.testTag("WalletAmountText"))
+                                        Text(
+                                            text = "Wallet",
+                                            color = colorScheme.onBackground,
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            modifier = Modifier.testTag("WalletText")
+                                        )
+                                        Text(
+                                            text = "___ CHF",
+                                            color = colorScheme.onBackground,
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            modifier = Modifier.testTag("WalletAmountText")
+                                        )
                                     }
-                                  }
                                 }
-                          }
+                            }
+                        }
 
-                      Spacer(modifier = Modifier.width(16.dp))
+                        Spacer(modifier = Modifier.width(16.dp))
 
-                      // Help Button
-                      Button(
-                          onClick = { /* Help click action */},
-                          modifier = Modifier.weight(1f).height(80.dp).testTag("HelpButton"),
-                          colors =
-                              ButtonDefaults.buttonColors(containerColor = colorScheme.surface),
-                          shape = RoundedCornerShape(8.dp),
-                          elevation = ButtonDefaults.buttonElevation(4.dp)) {
+                        // Help Button
+                        Button(
+                            onClick = { /* Help click action */ },
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(80.dp)
+                                .testTag("HelpButton"),
+                            colors =
+                            ButtonDefaults.buttonColors(containerColor = colorScheme.surface),
+                            shape = RoundedCornerShape(8.dp),
+                            elevation = ButtonDefaults.buttonElevation(4.dp)
+                        ) {
                             Column(
                                 horizontalAlignment = Alignment.Start,
                                 verticalArrangement = Arrangement.Center,
-                                modifier = Modifier.fillMaxWidth()) {
-                                  Row(verticalAlignment = Alignment.CenterVertically) {
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
                                     Icon(
                                         painter = painterResource(R.drawable.helpvector),
                                         contentDescription = "Help Icon",
                                         modifier = Modifier.size(30.dp),
-                                        tint = colorScheme.primary)
+                                        tint = colorScheme.primary
+                                    )
                                     Spacer(modifier = Modifier.width(35.dp))
                                     Text(
                                         text = "Help",
                                         color = colorScheme.onBackground,
                                         style = MaterialTheme.typography.bodyLarge,
-                                        modifier = Modifier.testTag("HelpText"))
-                                  }
+                                        modifier = Modifier.testTag("HelpText")
+                                    )
                                 }
-                          }
-                    }
-              }
-
-              Column(modifier = Modifier.fillMaxWidth()) {
-                options.forEach { option ->
-                  Card(
-                      modifier =
-                          Modifier.fillMaxWidth()
-                              .height(65.dp)
-                              .padding(vertical = 4.dp)
-                              .testTag(option.label.replace(" ", "") + "Option"),
-                      shape = RoundedCornerShape(8.dp),
-                      colors =
-                          CardDefaults.cardColors(
-                              containerColor = colorScheme.surface,
-                              contentColor = colorScheme.onBackground),
-                      elevation = CardDefaults.cardElevation(4.dp),
-                      onClick = option.onClick) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(16.dp),
-                            verticalAlignment = Alignment.CenterVertically) {
-                              when (val icon = option.icon) {
-                                is IconType.Resource -> {
-                                  Icon(
-                                      painter = painterResource(icon.resId),
-                                      contentDescription = "${option.label} Icon",
-                                      modifier = Modifier.size(24.dp),
-                                      tint = colorScheme.primary)
-                                }
-                                is IconType.Vector -> {
-                                  Icon(
-                                      imageVector = icon.imageVector,
-                                      contentDescription = "${option.label} Icon",
-                                      modifier = Modifier.size(24.dp),
-                                      tint = colorScheme.primary)
-                                }
-                              }
-                              Spacer(modifier = Modifier.width(16.dp))
-                              Text(
-                                  text = option.label,
-                                  style = MaterialTheme.typography.titleSmall,
-                                  modifier =
-                                      Modifier.testTag(option.label.replace(" ", "") + "Text"))
                             }
-                      }
-                }
-              }
-
-              // Logout Button
-              Button(
-                  onClick = {
-                    CoroutineScope(Dispatchers.IO).launch {
-                      preferencesViewModel.clearAllPreferences()
+                        }
                     }
-                    navigationActionsRoot.navigateTo(TopLevelDestinations.WELCOME)
-                    Log.d("user", Firebase.auth.currentUser.toString())
-                  },
-                  modifier =
-                      Modifier.fillMaxWidth().padding(vertical = 16.dp).testTag("LogoutButton"),
-                  colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)) {
+                }
+
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    options.forEach { option ->
+                        Card(
+                            modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .height(65.dp)
+                                .padding(vertical = 4.dp)
+                                .testTag(option.label.replace(" ", "") + "Option"),
+                            shape = RoundedCornerShape(8.dp),
+                            colors =
+                            CardDefaults.cardColors(
+                                containerColor = colorScheme.surface,
+                                contentColor = colorScheme.onBackground
+                            ),
+                            elevation = CardDefaults.cardElevation(4.dp),
+                            onClick = option.onClick
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                when (val icon = option.icon) {
+                                    is IconType.Resource -> {
+                                        Icon(
+                                            painter = painterResource(icon.resId),
+                                            contentDescription = "${option.label} Icon",
+                                            modifier = Modifier.size(24.dp),
+                                            tint = colorScheme.primary
+                                        )
+                                    }
+
+                                    is IconType.Vector -> {
+                                        Icon(
+                                            imageVector = icon.imageVector,
+                                            contentDescription = "${option.label} Icon",
+                                            modifier = Modifier.size(24.dp),
+                                            tint = colorScheme.primary
+                                        )
+                                    }
+                                }
+                                Spacer(modifier = Modifier.width(16.dp))
+                                Text(
+                                    text = option.label,
+                                    style = MaterialTheme.typography.titleSmall,
+                                    modifier =
+                                    Modifier.testTag(option.label.replace(" ", "") + "Text")
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Logout Button
+                Button(
+                    onClick = {
+                        clearAccountPreferences(preferencesViewModel)
+                        navigationActionsRoot.navigateTo(TopLevelDestinations.WELCOME)
+                        Log.d("user", Firebase.auth.currentUser.toString())
+                    },
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp)
+                        .testTag("LogoutButton"),
+                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary)
+                ) {
                     Text(
                         text = "Log out",
                         color = colorScheme.onPrimary,
                         style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.testTag("LogoutText"))
-                  }
+                        modifier = Modifier.testTag("LogoutText")
+                    )
+                }
             }
-      },
-  )
+        },
+    )
 }
 
 sealed class IconType {
-  data class Resource(val resId: Int) : IconType()
+    data class Resource(val resId: Int) : IconType()
 
-  data class Vector(val imageVector: ImageVector) : IconType()
+    data class Vector(val imageVector: ImageVector) : IconType()
 }
 
 data class OptionItem(val label: String, val icon: IconType, val onClick: () -> Unit)
 
 private fun capitalizeName(firstName: String?, lastName: String?): String {
-  val capitalizedFirstName = firstName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
-  val capitalizedLastName = lastName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
-  return "$capitalizedFirstName $capitalizedLastName".trim()
+    val capitalizedFirstName = firstName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
+    val capitalizedLastName = lastName?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""
+    return "$capitalizedFirstName $capitalizedLastName".trim()
 }

--- a/app/src/main/java/com/arygm/quickfix/utils/Preferences.kt
+++ b/app/src/main/java/com/arygm/quickfix/utils/Preferences.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 // =====Account Preferences=====//
 val IS_SIGN_IN_KEY = booleanPreferencesKey("is_sign_in")
@@ -25,105 +27,180 @@ fun setAccountPreferences(
     signIn: Boolean = true,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn)
-    preferencesViewModel.savePreference(UID_KEY, account.uid)
-    preferencesViewModel.savePreference(FIRST_NAME_KEY, account.firstName)
-    preferencesViewModel.savePreference(LAST_NAME_KEY, account.lastName)
-    preferencesViewModel.savePreference(EMAIL_KEY, account.email)
-    preferencesViewModel.savePreference(BIRTH_DATE_KEY, timestampToString(account.birthDate))
-    preferencesViewModel.savePreference(IS_WORKER_KEY, account.isWorker)
-  }
+    CoroutineScope(dispatcher).launch {
+        preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn)
+        preferencesViewModel.savePreference(UID_KEY, account.uid)
+        preferencesViewModel.savePreference(FIRST_NAME_KEY, account.firstName)
+        preferencesViewModel.savePreference(LAST_NAME_KEY, account.lastName)
+        preferencesViewModel.savePreference(EMAIL_KEY, account.email)
+        preferencesViewModel.savePreference(BIRTH_DATE_KEY, timestampToString(account.birthDate))
+        preferencesViewModel.savePreference(IS_WORKER_KEY, account.isWorker)
+    }
 }
 
-fun clearAccountPreferences(preferencesViewModel: PreferencesViewModel, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.clearAllPreferences()
-  }
+fun clearAccountPreferences(
+    preferencesViewModel: PreferencesViewModel,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    CoroutineScope(dispatcher).launch {
+        preferencesViewModel.clearAllPreferences()
+    }
 }
 
 // Setter functions
-fun setSignIn(preferencesViewModel: PreferencesViewModel, signIn: Boolean, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn)
-  }
+fun setSignIn(
+    preferencesViewModel: PreferencesViewModel,
+    signIn: Boolean,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    CoroutineScope(dispatcher).launch {
+        preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn)
+    }
 }
 
-fun setUserId(preferencesViewModel: PreferencesViewModel, userId: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.savePreference(UID_KEY, userId)
-  }
+fun setUserId(
+    preferencesViewModel: PreferencesViewModel,
+    userId: String,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    CoroutineScope(dispatcher).launch {
+        preferencesViewModel.savePreference(UID_KEY, userId)
+    }
 }
 
-fun setFirstName(preferencesViewModel: PreferencesViewModel, firstName: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.savePreference(FIRST_NAME_KEY, firstName)
-  }
+fun setFirstName(
+    preferencesViewModel: PreferencesViewModel,
+    firstName: String,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    CoroutineScope(dispatcher).launch {
+        preferencesViewModel.savePreference(FIRST_NAME_KEY, firstName)
+    }
 }
 
-fun setLastName(preferencesViewModel: PreferencesViewModel, lastName: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.savePreference(LAST_NAME_KEY, lastName)
-  }
+fun setLastName(
+    preferencesViewModel: PreferencesViewModel,
+    lastName: String,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    CoroutineScope(dispatcher).launch {
+        preferencesViewModel.savePreference(LAST_NAME_KEY, lastName)
+    }
 }
 
-fun setEmail(preferencesViewModel: PreferencesViewModel, email: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.savePreference(EMAIL_KEY, email)
-  }
+fun setEmail(
+    preferencesViewModel: PreferencesViewModel,
+    email: String,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    CoroutineScope(dispatcher).launch {
+        preferencesViewModel.savePreference(EMAIL_KEY, email)
+    }
 }
 
-fun setDateOfBirth(preferencesViewModel: PreferencesViewModel, dateOfBirth: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.savePreference(BIRTH_DATE_KEY, dateOfBirth)
-  }
+fun setBirthDate(
+    preferencesViewModel: PreferencesViewModel,
+    dateOfBirth: String,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    CoroutineScope(dispatcher).launch {
+        preferencesViewModel.savePreference(BIRTH_DATE_KEY, dateOfBirth)
+    }
 }
 
-fun setIsWorker(preferencesViewModel: PreferencesViewModel, isWorker: Boolean, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.savePreference(IS_WORKER_KEY, isWorker)
-  }
+fun setIsWorker(
+    preferencesViewModel: PreferencesViewModel,
+    isWorker: Boolean,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    CoroutineScope(dispatcher).launch {
+        preferencesViewModel.savePreference(IS_WORKER_KEY, isWorker)
+    }
 }
 
 // Loader functions
-fun loadIsSignIn(preferencesViewModel: PreferencesViewModel, onLoaded: (Boolean?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.loadPreference(IS_SIGN_IN_KEY, onLoaded)
-  }
+suspend fun loadIsSignIn(preferencesViewModel: PreferencesViewModel): Boolean {
+    return suspendCoroutine { cont ->
+        var resumed = false
+        preferencesViewModel.loadPreference(IS_SIGN_IN_KEY) { value ->
+            if (!resumed) {
+                resumed = true
+                cont.resume(value ?: false)
+            }
+        }
+    }
 }
 
-fun loadUserId(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.loadPreference(UID_KEY, onLoaded)
-  }
+suspend fun loadUserId(preferencesViewModel: PreferencesViewModel): String {
+    return suspendCoroutine { cont ->
+        var resumed = false
+        preferencesViewModel.loadPreference(FIRST_NAME_KEY) { value ->
+            if (!resumed) {
+                resumed = true
+
+                cont.resume(value ?: "no_first_name")
+            }
+        }
+    }
 }
 
-fun loadFirstName(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.loadPreference(FIRST_NAME_KEY, onLoaded)
-  }
+suspend fun loadFirstName(preferencesViewModel: PreferencesViewModel): String {
+    return suspendCoroutine { cont ->
+        var resumed = false
+        preferencesViewModel.loadPreference(FIRST_NAME_KEY) { value ->
+            if (!resumed) {
+                resumed = true
+                cont.resume(value ?: "no_first_name")
+            }
+        }
+    }
 }
 
-fun loadLastName(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.loadPreference(LAST_NAME_KEY, onLoaded)
-  }
+suspend fun loadLastName(preferencesViewModel: PreferencesViewModel): String {
+    return suspendCoroutine { cont ->
+        var resumed = false
+        preferencesViewModel.loadPreference(LAST_NAME_KEY) { value ->
+            if (!resumed) {
+                resumed = true
+                cont.resume(value ?: "no_last_name")
+            }
+        }
+    }
 }
 
-fun loadEmail(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.loadPreference(EMAIL_KEY, onLoaded)
-  }
+suspend fun loadEmail(preferencesViewModel: PreferencesViewModel): String {
+    return suspendCoroutine { cont ->
+        var resumed = false
+        preferencesViewModel.loadPreference(EMAIL_KEY) { value ->
+            if (!resumed) {
+                resumed = true
+                cont.resume(value ?: "no_email")
+            }
+        }
+    }
 }
 
-fun loadDateOfBirth(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.loadPreference(BIRTH_DATE_KEY, onLoaded)
-  }
+suspend fun loadBirthDate(preferencesViewModel: PreferencesViewModel): String {
+    return suspendCoroutine { cont ->
+        var resumed = false
+        preferencesViewModel.loadPreference(BIRTH_DATE_KEY) { value ->
+            if (!resumed) {
+                resumed = true
+                cont.resume(value ?: "no_birth_date")
+            }
+        }
+    }
 }
 
-fun loadIsWorker(preferencesViewModel: PreferencesViewModel, onLoaded: (Boolean?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-  CoroutineScope(dispatcher).launch {
-    preferencesViewModel.loadPreference(IS_WORKER_KEY, onLoaded)
-  }
+suspend fun loadIsWorker(preferencesViewModel: PreferencesViewModel): Boolean {
+    return suspendCoroutine { cont ->
+        var resumed = false
+        preferencesViewModel.loadPreference(IS_WORKER_KEY) { value ->
+            if (!resumed) {
+                resumed = true
+                cont.resume(value ?: false)
+            }
+        }
+    }
 }
+

--- a/app/src/main/java/com/arygm/quickfix/utils/Preferences.kt
+++ b/app/src/main/java/com/arygm/quickfix/utils/Preferences.kt
@@ -4,12 +4,12 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.arygm.quickfix.model.account.Account
 import com.arygm.quickfix.model.offline.small.PreferencesViewModel
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 // =====Account Preferences=====//
 val IS_SIGN_IN_KEY = booleanPreferencesKey("is_sign_in")
@@ -27,24 +27,22 @@ fun setAccountPreferences(
     signIn: Boolean = true,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-    CoroutineScope(dispatcher).launch {
-        preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn)
-        preferencesViewModel.savePreference(UID_KEY, account.uid)
-        preferencesViewModel.savePreference(FIRST_NAME_KEY, account.firstName)
-        preferencesViewModel.savePreference(LAST_NAME_KEY, account.lastName)
-        preferencesViewModel.savePreference(EMAIL_KEY, account.email)
-        preferencesViewModel.savePreference(BIRTH_DATE_KEY, timestampToString(account.birthDate))
-        preferencesViewModel.savePreference(IS_WORKER_KEY, account.isWorker)
-    }
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn)
+    preferencesViewModel.savePreference(UID_KEY, account.uid)
+    preferencesViewModel.savePreference(FIRST_NAME_KEY, account.firstName)
+    preferencesViewModel.savePreference(LAST_NAME_KEY, account.lastName)
+    preferencesViewModel.savePreference(EMAIL_KEY, account.email)
+    preferencesViewModel.savePreference(BIRTH_DATE_KEY, timestampToString(account.birthDate))
+    preferencesViewModel.savePreference(IS_WORKER_KEY, account.isWorker)
+  }
 }
 
 fun clearAccountPreferences(
     preferencesViewModel: PreferencesViewModel,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-    CoroutineScope(dispatcher).launch {
-        preferencesViewModel.clearAllPreferences()
-    }
+  CoroutineScope(dispatcher).launch { preferencesViewModel.clearAllPreferences() }
 }
 
 // Setter functions
@@ -53,9 +51,7 @@ fun setSignIn(
     signIn: Boolean,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-    CoroutineScope(dispatcher).launch {
-        preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn)
-    }
+  CoroutineScope(dispatcher).launch { preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn) }
 }
 
 fun setUserId(
@@ -63,9 +59,7 @@ fun setUserId(
     userId: String,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-    CoroutineScope(dispatcher).launch {
-        preferencesViewModel.savePreference(UID_KEY, userId)
-    }
+  CoroutineScope(dispatcher).launch { preferencesViewModel.savePreference(UID_KEY, userId) }
 }
 
 fun setFirstName(
@@ -73,9 +67,9 @@ fun setFirstName(
     firstName: String,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-    CoroutineScope(dispatcher).launch {
-        preferencesViewModel.savePreference(FIRST_NAME_KEY, firstName)
-    }
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(FIRST_NAME_KEY, firstName)
+  }
 }
 
 fun setLastName(
@@ -83,9 +77,7 @@ fun setLastName(
     lastName: String,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-    CoroutineScope(dispatcher).launch {
-        preferencesViewModel.savePreference(LAST_NAME_KEY, lastName)
-    }
+  CoroutineScope(dispatcher).launch { preferencesViewModel.savePreference(LAST_NAME_KEY, lastName) }
 }
 
 fun setEmail(
@@ -93,9 +85,7 @@ fun setEmail(
     email: String,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-    CoroutineScope(dispatcher).launch {
-        preferencesViewModel.savePreference(EMAIL_KEY, email)
-    }
+  CoroutineScope(dispatcher).launch { preferencesViewModel.savePreference(EMAIL_KEY, email) }
 }
 
 fun setBirthDate(
@@ -103,9 +93,9 @@ fun setBirthDate(
     dateOfBirth: String,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-    CoroutineScope(dispatcher).launch {
-        preferencesViewModel.savePreference(BIRTH_DATE_KEY, dateOfBirth)
-    }
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(BIRTH_DATE_KEY, dateOfBirth)
+  }
 }
 
 fun setIsWorker(
@@ -113,94 +103,91 @@ fun setIsWorker(
     isWorker: Boolean,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-    CoroutineScope(dispatcher).launch {
-        preferencesViewModel.savePreference(IS_WORKER_KEY, isWorker)
-    }
+  CoroutineScope(dispatcher).launch { preferencesViewModel.savePreference(IS_WORKER_KEY, isWorker) }
 }
 
 // Loader functions
 suspend fun loadIsSignIn(preferencesViewModel: PreferencesViewModel): Boolean {
-    return suspendCoroutine { cont ->
-        var resumed = false
-        preferencesViewModel.loadPreference(IS_SIGN_IN_KEY) { value ->
-            if (!resumed) {
-                resumed = true
-                cont.resume(value ?: false)
-            }
-        }
+  return suspendCoroutine { cont ->
+    var resumed = false
+    preferencesViewModel.loadPreference(IS_SIGN_IN_KEY) { value ->
+      if (!resumed) {
+        resumed = true
+        cont.resume(value ?: false)
+      }
     }
+  }
 }
 
 suspend fun loadUserId(preferencesViewModel: PreferencesViewModel): String {
-    return suspendCoroutine { cont ->
-        var resumed = false
-        preferencesViewModel.loadPreference(FIRST_NAME_KEY) { value ->
-            if (!resumed) {
-                resumed = true
+  return suspendCoroutine { cont ->
+    var resumed = false
+    preferencesViewModel.loadPreference(FIRST_NAME_KEY) { value ->
+      if (!resumed) {
+        resumed = true
 
-                cont.resume(value ?: "no_first_name")
-            }
-        }
+        cont.resume(value ?: "no_first_name")
+      }
     }
+  }
 }
 
 suspend fun loadFirstName(preferencesViewModel: PreferencesViewModel): String {
-    return suspendCoroutine { cont ->
-        var resumed = false
-        preferencesViewModel.loadPreference(FIRST_NAME_KEY) { value ->
-            if (!resumed) {
-                resumed = true
-                cont.resume(value ?: "no_first_name")
-            }
-        }
+  return suspendCoroutine { cont ->
+    var resumed = false
+    preferencesViewModel.loadPreference(FIRST_NAME_KEY) { value ->
+      if (!resumed) {
+        resumed = true
+        cont.resume(value ?: "no_first_name")
+      }
     }
+  }
 }
 
 suspend fun loadLastName(preferencesViewModel: PreferencesViewModel): String {
-    return suspendCoroutine { cont ->
-        var resumed = false
-        preferencesViewModel.loadPreference(LAST_NAME_KEY) { value ->
-            if (!resumed) {
-                resumed = true
-                cont.resume(value ?: "no_last_name")
-            }
-        }
+  return suspendCoroutine { cont ->
+    var resumed = false
+    preferencesViewModel.loadPreference(LAST_NAME_KEY) { value ->
+      if (!resumed) {
+        resumed = true
+        cont.resume(value ?: "no_last_name")
+      }
     }
+  }
 }
 
 suspend fun loadEmail(preferencesViewModel: PreferencesViewModel): String {
-    return suspendCoroutine { cont ->
-        var resumed = false
-        preferencesViewModel.loadPreference(EMAIL_KEY) { value ->
-            if (!resumed) {
-                resumed = true
-                cont.resume(value ?: "no_email")
-            }
-        }
+  return suspendCoroutine { cont ->
+    var resumed = false
+    preferencesViewModel.loadPreference(EMAIL_KEY) { value ->
+      if (!resumed) {
+        resumed = true
+        cont.resume(value ?: "no_email")
+      }
     }
+  }
 }
 
 suspend fun loadBirthDate(preferencesViewModel: PreferencesViewModel): String {
-    return suspendCoroutine { cont ->
-        var resumed = false
-        preferencesViewModel.loadPreference(BIRTH_DATE_KEY) { value ->
-            if (!resumed) {
-                resumed = true
-                cont.resume(value ?: "no_birth_date")
-            }
-        }
+  return suspendCoroutine { cont ->
+    var resumed = false
+    preferencesViewModel.loadPreference(BIRTH_DATE_KEY) { value ->
+      if (!resumed) {
+        resumed = true
+        cont.resume(value ?: "no_birth_date")
+      }
     }
+  }
 }
 
 suspend fun loadIsWorker(preferencesViewModel: PreferencesViewModel): Boolean {
-    return suspendCoroutine { cont ->
-        var resumed = false
-        preferencesViewModel.loadPreference(IS_WORKER_KEY) { value ->
-            if (!resumed) {
-                resumed = true
-                cont.resume(value ?: false)
-            }
-        }
+  return suspendCoroutine { cont ->
+    var resumed = false
+    preferencesViewModel.loadPreference(IS_WORKER_KEY) { value ->
+      if (!resumed) {
+        resumed = true
+        cont.resume(value ?: false)
+      }
     }
+  }
 }
-

--- a/app/src/main/java/com/arygm/quickfix/utils/Preferences.kt
+++ b/app/src/main/java/com/arygm/quickfix/utils/Preferences.kt
@@ -11,28 +11,119 @@ import kotlinx.coroutines.launch
 
 // =====Account Preferences=====//
 val IS_SIGN_IN_KEY = booleanPreferencesKey("is_sign_in")
-val USER_ID_KEY = stringPreferencesKey("user_id")
+val UID_KEY = stringPreferencesKey("user_id")
 val FIRST_NAME_KEY = stringPreferencesKey("first_name")
 val LAST_NAME_KEY = stringPreferencesKey("last_name")
 val EMAIL_KEY = stringPreferencesKey("email")
-val DATE_OF_BIRTH_KEY = stringPreferencesKey("date_of_birth")
+val BIRTH_DATE_KEY = stringPreferencesKey("date_of_birth")
 val IS_WORKER_KEY = booleanPreferencesKey("is_worker")
 
+// =====Helper functions======//
 fun setAccountPreferences(
     preferencesViewModel: PreferencesViewModel,
     account: Account,
     signIn: Boolean = true,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
-  // Use withContext rather than launching a new scope
-  // This ensures the code is executed in the caller's coroutine context
   CoroutineScope(dispatcher).launch {
     preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn)
-    preferencesViewModel.savePreference(USER_ID_KEY, account.uid)
+    preferencesViewModel.savePreference(UID_KEY, account.uid)
     preferencesViewModel.savePreference(FIRST_NAME_KEY, account.firstName)
     preferencesViewModel.savePreference(LAST_NAME_KEY, account.lastName)
     preferencesViewModel.savePreference(EMAIL_KEY, account.email)
-    preferencesViewModel.savePreference(DATE_OF_BIRTH_KEY, timestampToString(account.birthDate))
+    preferencesViewModel.savePreference(BIRTH_DATE_KEY, timestampToString(account.birthDate))
     preferencesViewModel.savePreference(IS_WORKER_KEY, account.isWorker)
+  }
+}
+
+fun clearAccountPreferences(preferencesViewModel: PreferencesViewModel, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.clearAllPreferences()
+  }
+}
+
+// Setter functions
+fun setSignIn(preferencesViewModel: PreferencesViewModel, signIn: Boolean, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(IS_SIGN_IN_KEY, signIn)
+  }
+}
+
+fun setUserId(preferencesViewModel: PreferencesViewModel, userId: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(UID_KEY, userId)
+  }
+}
+
+fun setFirstName(preferencesViewModel: PreferencesViewModel, firstName: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(FIRST_NAME_KEY, firstName)
+  }
+}
+
+fun setLastName(preferencesViewModel: PreferencesViewModel, lastName: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(LAST_NAME_KEY, lastName)
+  }
+}
+
+fun setEmail(preferencesViewModel: PreferencesViewModel, email: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(EMAIL_KEY, email)
+  }
+}
+
+fun setDateOfBirth(preferencesViewModel: PreferencesViewModel, dateOfBirth: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(BIRTH_DATE_KEY, dateOfBirth)
+  }
+}
+
+fun setIsWorker(preferencesViewModel: PreferencesViewModel, isWorker: Boolean, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.savePreference(IS_WORKER_KEY, isWorker)
+  }
+}
+
+// Loader functions
+fun loadIsSignIn(preferencesViewModel: PreferencesViewModel, onLoaded: (Boolean?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.loadPreference(IS_SIGN_IN_KEY, onLoaded)
+  }
+}
+
+fun loadUserId(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.loadPreference(UID_KEY, onLoaded)
+  }
+}
+
+fun loadFirstName(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.loadPreference(FIRST_NAME_KEY, onLoaded)
+  }
+}
+
+fun loadLastName(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.loadPreference(LAST_NAME_KEY, onLoaded)
+  }
+}
+
+fun loadEmail(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.loadPreference(EMAIL_KEY, onLoaded)
+  }
+}
+
+fun loadDateOfBirth(preferencesViewModel: PreferencesViewModel, onLoaded: (String?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.loadPreference(BIRTH_DATE_KEY, onLoaded)
+  }
+}
+
+fun loadIsWorker(preferencesViewModel: PreferencesViewModel, onLoaded: (Boolean?) -> Unit, dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  CoroutineScope(dispatcher).launch {
+    preferencesViewModel.loadPreference(IS_WORKER_KEY, onLoaded)
   }
 }

--- a/app/src/test/java/com/arygm/quickfix/utils/PreferencesTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/utils/PreferencesTest.kt
@@ -51,12 +51,12 @@ class PreferencesTest {
 
         // Assert
         verify(preferencesViewModel).savePreference(IS_SIGN_IN_KEY, true)
-        verify(preferencesViewModel).savePreference(USER_ID_KEY, "user123")
+        verify(preferencesViewModel).savePreference(UID_KEY, "user123")
         verify(preferencesViewModel).savePreference(FIRST_NAME_KEY, "Alice")
         verify(preferencesViewModel).savePreference(LAST_NAME_KEY, "Smith")
         verify(preferencesViewModel).savePreference(EMAIL_KEY, "alice.smith@example.com")
         // Adjust date string as per your timestampToString implementation
-        verify(preferencesViewModel).savePreference(DATE_OF_BIRTH_KEY, "15/05/1990")
+        verify(preferencesViewModel).savePreference(BIRTH_DATE_KEY, "15/05/1990")
         verify(preferencesViewModel).savePreference(IS_WORKER_KEY, true)
       }
 }

--- a/app/src/test/java/com/arygm/quickfix/utils/PreferencesTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/utils/PreferencesTest.kt
@@ -9,10 +9,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.*
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
+import org.mockito.kotlin.*
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PreferencesTest {
@@ -55,8 +55,77 @@ class PreferencesTest {
         verify(preferencesViewModel).savePreference(FIRST_NAME_KEY, "Alice")
         verify(preferencesViewModel).savePreference(LAST_NAME_KEY, "Smith")
         verify(preferencesViewModel).savePreference(EMAIL_KEY, "alice.smith@example.com")
-        // Adjust date string as per your timestampToString implementation
-        verify(preferencesViewModel).savePreference(BIRTH_DATE_KEY, "15/05/1990")
+        verify(preferencesViewModel)
+            .savePreference(
+                BIRTH_DATE_KEY,
+                "15/05/1990") // Ensure formatting matches your timestampToString implementation
         verify(preferencesViewModel).savePreference(IS_WORKER_KEY, true)
+      }
+
+  @Test
+  fun setSignInSavesSignInPreference() =
+      runTest(testDispatcher) {
+        // Act
+        setSignIn(preferencesViewModel, true, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).savePreference(IS_SIGN_IN_KEY, true)
+      }
+
+  @Test
+  fun loadIsSignInReturnsCorrectValue() =
+      runTest(testDispatcher) {
+        // Arrange
+        whenever(preferencesViewModel.loadPreference(eq(IS_SIGN_IN_KEY), any())).thenAnswer {
+            invocation ->
+          val callback = invocation.arguments[1] as (Boolean?) -> Unit
+          callback(true)
+        }
+
+        // Act
+        val result = loadIsSignIn(preferencesViewModel)
+
+        // Assert
+        assertEquals(true, result)
+      }
+
+  @Test
+  fun loadFirstNameReturnsCorrectValue() =
+      runTest(testDispatcher) {
+        // Arrange
+        whenever(preferencesViewModel.loadPreference(eq(FIRST_NAME_KEY), any())).thenAnswer {
+            invocation ->
+          val callback = invocation.arguments[1] as (String?) -> Unit
+          callback("Alice")
+        }
+
+        // Act
+        val result = loadFirstName(preferencesViewModel)
+
+        // Assert
+        assertEquals("Alice", result)
+      }
+
+  @Test
+  fun setFirstNameSavesFirstNamePreference() =
+      runTest(testDispatcher) {
+        // Act
+        setFirstName(preferencesViewModel, "Alice", dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).savePreference(FIRST_NAME_KEY, "Alice")
+      }
+
+  @Test
+  fun clearAccountPreferencesClearsAllPreferences() =
+      runTest(testDispatcher) {
+        // Act
+        clearAccountPreferences(preferencesViewModel, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).clearAllPreferences()
       }
 }

--- a/app/src/test/java/com/arygm/quickfix/utils/PreferencesTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/utils/PreferencesTest.kt
@@ -32,7 +32,7 @@ class PreferencesTest {
   }
 
   @Test
-  fun setAccountPreferencesSavesUserPreferences() =
+  fun setAccountPreferencesSavesAllPreferences() =
       runTest(testDispatcher) {
         // Arrange
         val account =
@@ -47,7 +47,7 @@ class PreferencesTest {
         // Act
         setAccountPreferences(
             preferencesViewModel, account, signIn = true, dispatcher = testDispatcher)
-        testScheduler.advanceUntilIdle() // Ensures all coroutines finish
+        testScheduler.advanceUntilIdle()
 
         // Assert
         verify(preferencesViewModel).savePreference(IS_SIGN_IN_KEY, true)
@@ -55,15 +55,23 @@ class PreferencesTest {
         verify(preferencesViewModel).savePreference(FIRST_NAME_KEY, "Alice")
         verify(preferencesViewModel).savePreference(LAST_NAME_KEY, "Smith")
         verify(preferencesViewModel).savePreference(EMAIL_KEY, "alice.smith@example.com")
-        verify(preferencesViewModel)
-            .savePreference(
-                BIRTH_DATE_KEY,
-                "15/05/1990") // Ensure formatting matches your timestampToString implementation
+        verify(preferencesViewModel).savePreference(BIRTH_DATE_KEY, "15/05/1990")
         verify(preferencesViewModel).savePreference(IS_WORKER_KEY, true)
       }
 
   @Test
-  fun setSignInSavesSignInPreference() =
+  fun clearAccountPreferencesClearsAllPreferences() =
+      runTest(testDispatcher) {
+        // Act
+        clearAccountPreferences(preferencesViewModel, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).clearAllPreferences()
+      }
+
+  @Test
+  fun setSignInSavesCorrectValue() =
       runTest(testDispatcher) {
         // Act
         setSignIn(preferencesViewModel, true, dispatcher = testDispatcher)
@@ -74,12 +82,77 @@ class PreferencesTest {
       }
 
   @Test
+  fun setUserIdSavesCorrectValue() =
+      runTest(testDispatcher) {
+        // Act
+        setUserId(preferencesViewModel, "user123", dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).savePreference(UID_KEY, "user123")
+      }
+
+  @Test
+  fun setFirstNameSavesCorrectValue() =
+      runTest(testDispatcher) {
+        // Act
+        setFirstName(preferencesViewModel, "Alice", dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).savePreference(FIRST_NAME_KEY, "Alice")
+      }
+
+  @Test
+  fun setLastNameSavesCorrectValue() =
+      runTest(testDispatcher) {
+        // Act
+        setLastName(preferencesViewModel, "Smith", dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).savePreference(LAST_NAME_KEY, "Smith")
+      }
+
+  @Test
+  fun setEmailSavesCorrectValue() =
+      runTest(testDispatcher) {
+        // Act
+        setEmail(preferencesViewModel, "alice.smith@example.com", dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).savePreference(EMAIL_KEY, "alice.smith@example.com")
+      }
+
+  @Test
+  fun setBirthDateSavesCorrectValue() =
+      runTest(testDispatcher) {
+        // Act
+        setBirthDate(preferencesViewModel, "15/05/1990", dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).savePreference(BIRTH_DATE_KEY, "15/05/1990")
+      }
+
+  @Test
+  fun setIsWorkerSavesCorrectValue() =
+      runTest(testDispatcher) {
+        // Act
+        setIsWorker(preferencesViewModel, true, dispatcher = testDispatcher)
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        verify(preferencesViewModel).savePreference(IS_WORKER_KEY, true)
+      }
+
+  @Test
   fun loadIsSignInReturnsCorrectValue() =
       runTest(testDispatcher) {
         // Arrange
         whenever(preferencesViewModel.loadPreference(eq(IS_SIGN_IN_KEY), any())).thenAnswer {
-            invocation ->
-          val callback = invocation.arguments[1] as (Boolean?) -> Unit
+          val callback = it.getArgument<(Boolean?) -> Unit>(1)
           callback(true)
         }
 
@@ -95,8 +168,7 @@ class PreferencesTest {
       runTest(testDispatcher) {
         // Arrange
         whenever(preferencesViewModel.loadPreference(eq(FIRST_NAME_KEY), any())).thenAnswer {
-            invocation ->
-          val callback = invocation.arguments[1] as (String?) -> Unit
+          val callback = it.getArgument<(String?) -> Unit>(1)
           callback("Alice")
         }
 
@@ -108,24 +180,66 @@ class PreferencesTest {
       }
 
   @Test
-  fun setFirstNameSavesFirstNamePreference() =
+  fun loadLastNameReturnsCorrectValue() =
       runTest(testDispatcher) {
+        // Arrange
+        whenever(preferencesViewModel.loadPreference(eq(LAST_NAME_KEY), any())).thenAnswer {
+          val callback = it.getArgument<(String?) -> Unit>(1)
+          callback("Smith")
+        }
+
         // Act
-        setFirstName(preferencesViewModel, "Alice", dispatcher = testDispatcher)
-        testScheduler.advanceUntilIdle()
+        val result = loadLastName(preferencesViewModel)
 
         // Assert
-        verify(preferencesViewModel).savePreference(FIRST_NAME_KEY, "Alice")
+        assertEquals("Smith", result)
       }
 
   @Test
-  fun clearAccountPreferencesClearsAllPreferences() =
+  fun loadEmailReturnsCorrectValue() =
       runTest(testDispatcher) {
+        // Arrange
+        whenever(preferencesViewModel.loadPreference(eq(EMAIL_KEY), any())).thenAnswer {
+          val callback = it.getArgument<(String?) -> Unit>(1)
+          callback("alice.smith@example.com")
+        }
+
         // Act
-        clearAccountPreferences(preferencesViewModel, dispatcher = testDispatcher)
-        testScheduler.advanceUntilIdle()
+        val result = loadEmail(preferencesViewModel)
 
         // Assert
-        verify(preferencesViewModel).clearAllPreferences()
+        assertEquals("alice.smith@example.com", result)
+      }
+
+  @Test
+  fun loadBirthDateReturnsCorrectValue() =
+      runTest(testDispatcher) {
+        // Arrange
+        whenever(preferencesViewModel.loadPreference(eq(BIRTH_DATE_KEY), any())).thenAnswer {
+          val callback = it.getArgument<(String?) -> Unit>(1)
+          callback("15/05/1990")
+        }
+
+        // Act
+        val result = loadBirthDate(preferencesViewModel)
+
+        // Assert
+        assertEquals("15/05/1990", result)
+      }
+
+  @Test
+  fun loadIsWorkerReturnsCorrectValue() =
+      runTest(testDispatcher) {
+        // Arrange
+        whenever(preferencesViewModel.loadPreference(eq(IS_WORKER_KEY), any())).thenAnswer {
+          val callback = it.getArgument<(Boolean?) -> Unit>(1)
+          callback(true)
+        }
+
+        // Act
+        val result = loadIsWorker(preferencesViewModel)
+
+        // Assert
+        assertEquals(true, result)
       }
 }


### PR DESCRIPTION
Second PR towards implementing a fully fledged _**offline mode**_. It is no secret that it currently is very cumbersome to use the `PreferencesViewModel` in its current state: Having to use a co-routine or a `LaunchedEffect` for every call and having to nest cache calls to load multiple values is very stinky... 

Thus, this PR brings a few nice changes to make it easier to call the cache.

_**Commit history**_:

`task: add helper functions and refactor utils`
- [x] Add cache setter functions for every field
- [x] Add cache loader functions for every field
- [x] Refactor confusing keynames 

`task: update screens to use helper functions`
- [x] Update necessary files¹

`test: test new methods and ktfmt format`

###### ¹: These new functions only truly work for synchronous queries