### PR TITLE
task: add offline bar element and implement it with main activity

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixOfflineBarTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixOfflineBarTest.kt
@@ -1,0 +1,33 @@
+package com.arygm.quickfix.ui.elements
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.Rule
+import org.junit.Test
+
+class QuickFixOfflineBarTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun offlineBar_isVisible_whenIsVisibleIsTrue() {
+    val isVisible = mutableStateOf(true)
+
+    composeTestRule.setContent { MaterialTheme { QuickFixOfflineBar(isVisible = isVisible.value) } }
+
+    // Assert the bar is displayed with the correct text
+    composeTestRule.onNodeWithText("No Internet Connection").assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun offlineBar_isHidden_whenIsVisibleIsFalse() {
+    val isVisible = mutableStateOf(false)
+
+    composeTestRule.setContent { MaterialTheme { QuickFixOfflineBar(isVisible = isVisible.value) } }
+
+    // Assert the bar is not displayed
+    composeTestRule.onNodeWithText("No Internet Connection").assertDoesNotExist()
+  }
+}

--- a/app/src/main/java/com/arygm/quickfix/MainActivity.kt
+++ b/app/src/main/java/com/arygm/quickfix/MainActivity.kt
@@ -2,6 +2,8 @@ package com.arygm.quickfix
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -50,6 +52,7 @@ import com.arygm.quickfix.ui.authentication.WelcomeScreen
 import com.arygm.quickfix.ui.camera.QuickFixDisplayImages
 import com.arygm.quickfix.ui.dashboard.DashboardScreen
 import com.arygm.quickfix.ui.elements.LocationSearchCustomScreen
+import com.arygm.quickfix.ui.elements.QuickFixOfflineBar
 import com.arygm.quickfix.ui.home.FakeMessageScreen
 import com.arygm.quickfix.ui.home.HomeScreen
 import com.arygm.quickfix.ui.navigation.BottomNavigationMenu
@@ -118,7 +121,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 @Preview
 fun QuickFixApp() {
-
+    val context = LocalContext.current
   val rootNavController = rememberNavController()
   val navigationActionsRoot = remember { NavigationActions(rootNavController) }
 
@@ -168,6 +171,16 @@ fun QuickFixApp() {
 
   var showBottomBar by remember { mutableStateOf(false) }
 
+    var isOffline by remember { mutableStateOf(!isConnectedToInternet(context)) }
+
+    // Simulate monitoring connectivity (replace this with actual monitoring in production)
+    LaunchedEffect(Unit) {
+        while (true) {
+            isOffline = !isConnectedToInternet(context)
+            delay(3000) // Poll every 3 seconds
+        }
+    }
+
   // Delay the appearance of the bottom bar
   LaunchedEffect(shouldShowBottomBar) {
     if (shouldShowBottomBar) {
@@ -179,6 +192,9 @@ fun QuickFixApp() {
   }
 
   Scaffold(
+      topBar = {
+          QuickFixOfflineBar(isVisible = isOffline)
+      },
       bottomBar = {
         // Show BottomNavigationMenu only if the route is not part of the login/registration flow
         AnimatedVisibility(
@@ -290,6 +306,14 @@ fun HomeNavHost(
       FakeMessageScreen(navigationActions)
     }
   }
+}
+
+fun isConnectedToInternet(context: Context): Boolean {
+    val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    val network = connectivityManager.activeNetwork ?: return false
+    val activeNetwork = connectivityManager.getNetworkCapabilities(network) ?: return false
+    return activeNetwork.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
 }
 
 @Composable

--- a/app/src/main/java/com/arygm/quickfix/MainActivity.kt
+++ b/app/src/main/java/com/arygm/quickfix/MainActivity.kt
@@ -121,7 +121,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 @Preview
 fun QuickFixApp() {
-    val context = LocalContext.current
+  val context = LocalContext.current
   val rootNavController = rememberNavController()
   val navigationActionsRoot = remember { NavigationActions(rootNavController) }
 
@@ -171,15 +171,15 @@ fun QuickFixApp() {
 
   var showBottomBar by remember { mutableStateOf(false) }
 
-    var isOffline by remember { mutableStateOf(!isConnectedToInternet(context)) }
+  var isOffline by remember { mutableStateOf(!isConnectedToInternet(context)) }
 
-    // Simulate monitoring connectivity (replace this with actual monitoring in production)
-    LaunchedEffect(Unit) {
-        while (true) {
-            isOffline = !isConnectedToInternet(context)
-            delay(3000) // Poll every 3 seconds
-        }
+  // Simulate monitoring connectivity (replace this with actual monitoring in production)
+  LaunchedEffect(Unit) {
+    while (true) {
+      isOffline = !isConnectedToInternet(context)
+      delay(3000) // Poll every 3 seconds
     }
+  }
 
   // Delay the appearance of the bottom bar
   LaunchedEffect(shouldShowBottomBar) {
@@ -192,9 +192,7 @@ fun QuickFixApp() {
   }
 
   Scaffold(
-      topBar = {
-          QuickFixOfflineBar(isVisible = isOffline)
-      },
+      topBar = { QuickFixOfflineBar(isVisible = isOffline) },
       bottomBar = {
         // Show BottomNavigationMenu only if the route is not part of the login/registration flow
         AnimatedVisibility(
@@ -309,11 +307,11 @@ fun HomeNavHost(
 }
 
 fun isConnectedToInternet(context: Context): Boolean {
-    val connectivityManager =
-        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-    val network = connectivityManager.activeNetwork ?: return false
-    val activeNetwork = connectivityManager.getNetworkCapabilities(network) ?: return false
-    return activeNetwork.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+  val connectivityManager =
+      context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+  val network = connectivityManager.activeNetwork ?: return false
+  val activeNetwork = connectivityManager.getNetworkCapabilities(network) ?: return false
+  return activeNetwork.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
 }
 
 @Composable

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixOfflineBar.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixOfflineBar.kt
@@ -14,24 +14,19 @@ import androidx.compose.ui.unit.sp
 
 @Composable
 fun QuickFixOfflineBar(isVisible: Boolean) {
-    AnimatedVisibility(
-        visible = isVisible,
-        enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
-        exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut()
-    ) {
+  AnimatedVisibility(
+      visible = isVisible,
+      enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
+      exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut()) {
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.error)
-                .padding(16.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = "No Internet Connection",
-                color = MaterialTheme.colorScheme.background,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Bold
-            )
-        }
-    }
+            modifier =
+                Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.error).padding(16.dp),
+            contentAlignment = Alignment.Center) {
+              Text(
+                  text = "No Internet Connection",
+                  color = MaterialTheme.colorScheme.background,
+                  fontSize = 16.sp,
+                  fontWeight = FontWeight.Bold)
+            }
+      }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixOfflineBar.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixOfflineBar.kt
@@ -1,0 +1,37 @@
+package com.arygm.quickfix.ui.elements
+
+import androidx.compose.animation.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun QuickFixOfflineBar(isVisible: Boolean) {
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
+        exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut()
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.error)
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "No Internet Connection",
+                color = MaterialTheme.colorScheme.background,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}


### PR DESCRIPTION
One of the last remaining puzzle pieces to finally finish the _**Offline Mode**_. That is, an indicator warning the user that the app is not connected to the internet. 

_**Commit history:**_

`task: add offline bar element and implement it with main activity`
- [x] Add `QuickFixOfflineBar` in `elements`
- [x] Update `MainActivity.kt` to accurately reflect whether or not the user is connected. 

`test: add tests for offline bar and ktfmt format`
