### PR TITLE
Refine Filter Interactions and SearchViewModel and Filter Composables

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/ChooseServiceTypeSheetTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/ChooseServiceTypeSheetTest.kt
@@ -1,6 +1,9 @@
 package com.arygm.quickfix.ui.elements
 
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -74,10 +77,7 @@ class ChooseServiceTypeSheetTest {
     }
 
     // Click on Apply button
-    composeTestRule.onNodeWithTag("applyButton").performClick()
-
-    // Verify the apply callback is triggered with an empty list
-    verify(onApplyClick).invoke(emptyList())
+    composeTestRule.onNodeWithTag("applyButton").assertIsNotEnabled()
   }
 
   @Test
@@ -239,5 +239,112 @@ class ChooseServiceTypeSheetTest {
       assert(!clearCalled) { "Expected onClearClick not to be called" }
       assert(!dismissCalled) { "Expected onDismissRequest not to be called" }
     }
+  }
+
+  @Test
+  fun chooseServiceTypeSheet_initialSelectedServices_areRespected() {
+    val serviceTypes = listOf("Exterior Painter", "Interior Painter")
+    val initiallySelected = listOf("Exterior Painter")
+
+    composeTestRule.setContent {
+      QuickFixTheme {
+        ChooseServiceTypeSheet(
+            showModalBottomSheet = true,
+            serviceTypes = serviceTypes,
+            selectedServices = initiallySelected,
+            onApplyClick = onApplyClick,
+            onDismissRequest = onDismissRequest,
+            onClearClick = {},
+            clearEnabled = false)
+      }
+    }
+
+    // The "Exterior Painter" option should appear as selected (background and text color check is
+    // UI-based,
+    // but we can at least verify that it was clickable and is displayed):
+    composeTestRule.onNodeWithTag("serviceText_Exterior Painter").assertIsDisplayed()
+
+    // Verify that the apply button is enabled since we have an initially selected service
+    composeTestRule.onNodeWithTag("applyButton").assertIsDisplayed().assertHasClickAction()
+
+    // Click on Apply button
+    composeTestRule.onNodeWithTag("applyButton").performClick()
+
+    // Verify the apply callback is triggered with the initially selected service
+    verify(onApplyClick).invoke(initiallySelected)
+  }
+
+  @Test
+  fun chooseServiceTypeSheet_noInitialSelection_applyDisabledUntilSelection() {
+    val serviceTypes = listOf("Exterior Painter", "Interior Painter")
+
+    composeTestRule.setContent {
+      QuickFixTheme {
+        ChooseServiceTypeSheet(
+            showModalBottomSheet = true,
+            serviceTypes = serviceTypes,
+            selectedServices = emptyList(), // No initial selection
+            onApplyClick = onApplyClick,
+            onDismissRequest = onDismissRequest,
+            onClearClick = {},
+            clearEnabled = false)
+      }
+    }
+
+    // Initially, apply button should be disabled
+    composeTestRule
+        .onNodeWithTag("applyButton")
+        .assertIsDisplayed()
+        .assertIsNotEnabled() // There's no direct assert for "disabled", but we can check action
+                              // availability
+
+    // Select a service
+    composeTestRule.onNodeWithTag("serviceText_Exterior Painter").performClick()
+
+    // Now apply button should be enabled
+    // Since there's no direct built-in assert for "enabled" state, we rely on the action
+    // availability:
+    composeTestRule.onNodeWithTag("applyButton").assertIsDisplayed().assertIsEnabled()
+
+    // Click on Apply button
+    composeTestRule.onNodeWithTag("applyButton").performClick()
+
+    // Verify the apply callback is triggered with the newly selected service
+    verify(onApplyClick).invoke(listOf("Exterior Painter"))
+  }
+
+  @Test
+  fun chooseServiceTypeSheet_initialSelectedServices_clearWorks() {
+    val serviceTypes = listOf("Exterior Painter", "Interior Painter")
+    var clearCalled = false
+    var dismissCalled = false
+
+    composeTestRule.setContent {
+      QuickFixTheme {
+        ChooseServiceTypeSheet(
+            showModalBottomSheet = true,
+            serviceTypes = serviceTypes,
+            selectedServices = listOf("Exterior Painter"), // Initially selected
+            onApplyClick = onApplyClick,
+            onDismissRequest = { dismissCalled = true },
+            onClearClick = { clearCalled = true },
+            clearEnabled = true)
+      }
+    }
+
+    // "Apply" is enabled initially since a service is selected
+    composeTestRule.onNodeWithTag("applyButton").assertIsDisplayed().assertIsEnabled()
+
+    // Click on Clear button
+    composeTestRule.onNodeWithTag("resetButton").performClick()
+
+    // After clearing, the onClearClick callback should be called and the dialog dismissed
+    composeTestRule.runOnIdle {
+      assert(clearCalled) { "Expected onClearClick to be called" }
+      assert(dismissCalled) { "Expected onDismissRequest to be called" }
+    }
+
+    // No apply action should have been triggered with the initial selection since we cleared it
+    verify(onApplyClick, never()).invoke(anyList())
   }
 }

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/ChooseServiceTypeSheetTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/ChooseServiceTypeSheetTest.kt
@@ -296,7 +296,7 @@ class ChooseServiceTypeSheetTest {
         .onNodeWithTag("applyButton")
         .assertIsDisplayed()
         .assertIsNotEnabled() // There's no direct assert for "disabled", but we can check action
-                              // availability
+    // availability
 
     // Select a service
     composeTestRule.onNodeWithTag("serviceText_Exterior Painter").performClick()

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixAvailabilityBottomSheetTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixAvailabilityBottomSheetTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arygm.quickfix.utils.inToMonth
 import java.time.LocalDate
 import org.junit.Rule
 import org.junit.Test
@@ -90,7 +91,7 @@ class QuickFixAvailabilityBottomSheetTest {
 
     // Get today's date
     val today = LocalDate.now()
-    val todayDayOfMonth = today.dayOfMonth.toString()
+    val month = inToMonth(today.month.value)
 
     composeTestRule.setContent {
       QuickFixAvailabilityBottomSheet(
@@ -122,7 +123,9 @@ class QuickFixAvailabilityBottomSheetTest {
     textFields[1].performTextReplacement("00")
 
     // Find the node representing today's date and perform a click
-    composeTestRule.onNode(hasText(todayDayOfMonth) and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText(month) and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText("Jan") and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText("1") and hasClickAction()).performClick()
 
     // Simulate pressing the OK button (if there is one)
     // If the CalendarView has an OK button, we need to perform a click on it
@@ -132,7 +135,7 @@ class QuickFixAvailabilityBottomSheetTest {
     // Assert that onOkClick was called
     composeTestRule.runOnIdle {
       assert(onOkClickCalled)
-      assert(selectedDates.contains(today))
+      assert(selectedDates.contains(LocalDate.of(today.year, 1, 1)))
       assert(selectedHour == 7)
       assert(selectedMinute == 0)
     }

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixDateTimePickerTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixDateTimePickerTest.kt
@@ -2,6 +2,7 @@ package com.arygm.quickfix.ui.elements
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.arygm.quickfix.utils.inToMonth
 import java.time.LocalDate
 import java.time.LocalTime
 import org.junit.Rule
@@ -20,22 +21,22 @@ class QuickFixDateTimePickerTest {
           onDismissRequest = {},
           timeViewTest = false)
     }
+    val today = LocalDate.now()
 
     // Assert DatePickerDialog is displayed
     composeTestRule.onNodeWithText("Select Date").assertIsDisplayed()
 
     // Simulate date selection
-    composeTestRule.onNodeWithText("${LocalDate.now().dayOfMonth}").performClick()
+    composeTestRule.onNodeWithText(inToMonth(today.month.value)).performClick()
+    composeTestRule.onNodeWithText("Jan").performClick()
+    composeTestRule.onNodeWithText("1").performClick()
     composeTestRule.onNodeWithText("OK").performClick()
 
     composeTestRule.onNodeWithText("OK").performClick()
 
     // Assert that selectedDate is updated
     assert(selectedDate != null)
-    assert(
-        selectedDate ==
-            LocalDate.of(
-                LocalDate.now().year, LocalDate.now().monthValue, LocalDate.now().dayOfMonth))
+    assert(selectedDate == LocalDate.of(LocalDate.now().year, 1, 1))
   }
 
   @Test
@@ -47,9 +48,12 @@ class QuickFixDateTimePickerTest {
           onDismissRequest = {},
           timeViewTest = false)
     }
+    val today = LocalDate.now()
 
     // Simulate date selection to advance to time picker
-    composeTestRule.onNodeWithText("${LocalDate.now().dayOfMonth}").performClick() // Select a date
+    composeTestRule.onNodeWithText(inToMonth(today.month.value)).performClick()
+    composeTestRule.onNodeWithText("Jan").performClick()
+    composeTestRule.onNodeWithText("1").performClick()
     composeTestRule.onNodeWithText("OK").performClick()
 
     // Assert TimePickerDialog is displayed
@@ -114,9 +118,12 @@ class QuickFixDateTimePickerTest {
           onDismissRequest = {},
           timeViewTest = false)
     }
+    val today = LocalDate.now()
 
     // Select date
-    composeTestRule.onNodeWithText("${LocalDate.now().dayOfMonth}").performClick()
+    composeTestRule.onNodeWithText(inToMonth(today.month.value)).performClick()
+    composeTestRule.onNodeWithText("Jan").performClick()
+    composeTestRule.onNodeWithText("1").performClick()
     composeTestRule.onNodeWithText("OK").performClick()
 
     // Select time
@@ -129,10 +136,7 @@ class QuickFixDateTimePickerTest {
 
     // Assert that date and time are passed correctly
     assert(selectedDateTime != null)
-    assert(
-        selectedDateTime?.first ==
-            LocalDate.of(
-                LocalDate.now().year, LocalDate.now().monthValue, LocalDate.now().dayOfMonth))
+    assert(selectedDateTime?.first == LocalDate.of(LocalDate.now().year, 1, 1))
     assert(selectedDateTime?.second == LocalTime.of(14, LocalTime.now().minute))
   }
 }

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/quickfix/QuickFixFirstStepTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/quickfix/QuickFixFirstStepTest.kt
@@ -11,6 +11,7 @@ import com.arygm.quickfix.model.profile.ProfileViewModel
 import com.arygm.quickfix.model.quickfix.QuickFixRepository
 import com.arygm.quickfix.model.quickfix.QuickFixViewModel
 import com.arygm.quickfix.ui.navigation.NavigationActions
+import com.arygm.quickfix.utils.inToMonth
 import java.time.LocalDate
 import org.junit.Before
 import org.junit.Rule
@@ -118,13 +119,17 @@ class QuickFixFirstStepTest {
           quickFixViewModel = quickFixViewModel)
     }
 
+    val today = LocalDate.now()
+
     // Open the date picker
     composeTestRule.onNodeWithText("Add Suggested Date").performClick()
     // Assert the date picker is displayed
     composeTestRule.onNodeWithText("Select Date").assertExists()
 
     // Simulate selecting a date
-    composeTestRule.onNodeWithText("${LocalDate.now().dayOfMonth}").performClick()
+    composeTestRule.onNodeWithText(inToMonth(today.month.value)).performClick()
+    composeTestRule.onNodeWithText("Jan").performClick()
+    composeTestRule.onNodeWithText("1").performClick()
     composeTestRule.onNodeWithText("OK").performClick()
 
     composeTestRule.onNodeWithText("OK").performClick()

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/SearchWorkerResultScreenTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/SearchWorkerResultScreenTest.kt
@@ -39,6 +39,7 @@ import com.arygm.quickfix.model.profile.WorkerProfile
 import com.arygm.quickfix.model.profile.WorkerProfileRepositoryFirestore
 import com.arygm.quickfix.model.search.SearchViewModel
 import com.arygm.quickfix.ui.navigation.NavigationActions
+import com.arygm.quickfix.utils.inToMonth
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,7 +98,7 @@ class SearchWorkerResultScreenTest {
     userViewModel = ProfileViewModel(userProfileRepositoryFirestore)
 
     // Provide test data to SearchViewModel
-    searchViewModel._workerProfiles.value =
+    searchViewModel._subCategoryWorkerProfiles.value =
         listOf(
             WorkerProfile(
                 uid = "test_uid_1",
@@ -191,8 +192,9 @@ class SearchWorkerResultScreenTest {
     // Wait for the UI to settle
     composeTestRule.waitForIdle()
 
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
     // Verify that the LazyRow for filter buttons is visible
-    val filterButtonsRow = composeTestRule.onNodeWithTag("filter_buttons_row")
+    val filterButtonsRow = composeTestRule.onNodeWithTag("lazy_filter_row")
     filterButtonsRow.assertExists().assertIsDisplayed()
 
     // Define the expected button texts
@@ -552,7 +554,7 @@ class SearchWorkerResultScreenTest {
             fieldOfWork = "Painter",
             rating = 4.5,
             workingHours = Pair(LocalTime.of(9, 0), LocalTime.of(17, 0)),
-            unavailability_list = listOf(LocalDate.now()),
+            unavailability_list = listOf(LocalDate.of(LocalDate.now().year, 1, 1)),
             location = Location(0.0, 0.0))
 
     val worker2 =
@@ -574,7 +576,7 @@ class SearchWorkerResultScreenTest {
             location = Location(0.0, 0.0))
 
     // Update the searchViewModel with these test workers
-    searchViewModel._workerProfiles.value = listOf(worker1, worker2, worker3)
+    searchViewModel._subCategoryWorkerProfiles.value = listOf(worker1, worker2, worker3)
 
     // Set the composable content
     composeTestRule.setContent {
@@ -588,7 +590,8 @@ class SearchWorkerResultScreenTest {
     // Verify that all 3 workers are displayed
     composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(3)
 
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(3)
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(3)
     // Simulate clicking the "Availability" filter button
     composeTestRule.onNodeWithText("Availability").performClick()
 
@@ -604,7 +607,7 @@ class SearchWorkerResultScreenTest {
     composeTestRule.onNodeWithText("Enter time").assertIsDisplayed()
 
     val today = LocalDate.now()
-    val todayDayOfMonth = today.dayOfMonth.toString()
+    val month = inToMonth(today.month.value)
 
     val textFields =
         composeTestRule.onAllNodes(hasSetTextAction()).filter(hasParent(hasTestTag("timeInput")))
@@ -619,7 +622,9 @@ class SearchWorkerResultScreenTest {
     textFields[1].performTextReplacement("00")
 
     // Find the node representing today's date and perform a click
-    composeTestRule.onNode(hasText(todayDayOfMonth) and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText(month) and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText("Jan") and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText("1") and hasClickAction()).performClick()
 
     composeTestRule.onNodeWithText("OK").performClick()
 
@@ -660,7 +665,7 @@ class SearchWorkerResultScreenTest {
             location = Location(0.0, 0.0))
 
     // Update the searchViewModel with these test workers
-    searchViewModel._workerProfiles.value = listOf(worker1, worker2, worker3)
+    searchViewModel._subCategoryWorkerProfiles.value = listOf(worker1, worker2, worker3)
 
     // Set the composable content
     composeTestRule.setContent {
@@ -674,7 +679,8 @@ class SearchWorkerResultScreenTest {
     // Verify that all 3 workers are displayed
     composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(3)
 
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(3)
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(3)
     // Simulate clicking the "Availability" filter button
     composeTestRule.onNodeWithText("Availability").performClick()
 
@@ -690,7 +696,7 @@ class SearchWorkerResultScreenTest {
     composeTestRule.onNodeWithText("Enter time").assertIsDisplayed()
 
     val today = LocalDate.now()
-    val todayDayOfMonth = today.dayOfMonth.toString()
+    val month = inToMonth(today.month.value)
 
     val textFields =
         composeTestRule.onAllNodes(hasSetTextAction()).filter(hasParent(hasTestTag("timeInput")))
@@ -705,7 +711,9 @@ class SearchWorkerResultScreenTest {
     textFields[1].performTextReplacement("00")
 
     // Find the node representing today's date and perform a click
-    composeTestRule.onNode(hasText(todayDayOfMonth) and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText(month) and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText("Jan") and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText("1") and hasClickAction()).performClick()
 
     composeTestRule.onNodeWithText("OK").performClick()
 
@@ -746,7 +754,7 @@ class SearchWorkerResultScreenTest {
             location = Location(0.0, 0.0))
 
     // Update the searchViewModel with these test workers
-    searchViewModel._workerProfiles.value = listOf(worker1, worker2, worker3)
+    searchViewModel._subCategoryWorkerProfiles.value = listOf(worker1, worker2, worker3)
 
     // Set the composable content
     composeTestRule.setContent {
@@ -760,7 +768,8 @@ class SearchWorkerResultScreenTest {
     // Verify that all 3 workers are displayed
     composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(3)
 
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(3)
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(3)
     // Simulate clicking the "Availability" filter button
     composeTestRule.onNodeWithText("Availability").performClick()
 
@@ -776,7 +785,7 @@ class SearchWorkerResultScreenTest {
     composeTestRule.onNodeWithText("Enter time").assertIsDisplayed()
 
     val today = LocalDate.now()
-    val todayDayOfMonth = today.dayOfMonth.toString()
+    val month = inToMonth(today.month.value)
 
     val textFields =
         composeTestRule.onAllNodes(hasSetTextAction()).filter(hasParent(hasTestTag("timeInput")))
@@ -791,7 +800,9 @@ class SearchWorkerResultScreenTest {
     textFields[1].performTextReplacement("00")
 
     // Find the node representing today's date and perform a click
-    composeTestRule.onNode(hasText(todayDayOfMonth) and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText(month) and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText("Jan") and hasClickAction()).performClick()
+    composeTestRule.onNode(hasText("1") and hasClickAction()).performClick()
 
     composeTestRule.onNodeWithText("OK").performClick()
 
@@ -817,13 +828,15 @@ class SearchWorkerResultScreenTest {
     searchViewModel._searchSubcategory.value =
         Subcategory(tags = listOf("Exterior Painter", "Interior Painter", "Electrician", "Plumber"))
 
-    searchViewModel._workerProfiles.value = workers
+    searchViewModel._subCategoryWorkerProfiles.value = workers
 
     composeTestRule.setContent {
       SearchWorkerResult(
           navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
     }
 
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(1)
     // Click on the "Service Type" filter button
     composeTestRule.onNodeWithText("Service Type").performClick()
 
@@ -863,7 +876,7 @@ class SearchWorkerResultScreenTest {
                 rating = 2.9))
 
     // Provide test data to the searchViewModel
-    searchViewModel._workerProfiles.value = workers
+    searchViewModel._subCategoryWorkerProfiles.value = workers
     searchViewModel._searchSubcategory.value =
         Subcategory(tags = listOf("Exterior Painter", "Interior Painter", "Electrician", "Plumber"))
 
@@ -872,8 +885,9 @@ class SearchWorkerResultScreenTest {
           navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
     }
 
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
     // Scroll to the "Highest Rating" button in the LazyRow
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(3)
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(3)
 
     // Click on the "Highest Rating" filter button
     composeTestRule.onNodeWithText("Highest Rating").performClick()
@@ -912,7 +926,7 @@ class SearchWorkerResultScreenTest {
                 rating = 2.9))
 
     // Provide test data to the searchViewModel
-    searchViewModel._workerProfiles.value = workers
+    searchViewModel._subCategoryWorkerProfiles.value = workers
     searchViewModel._searchSubcategory.value =
         Subcategory(tags = listOf("Exterior Painter", "Interior Painter", "Electrician", "Plumber"))
 
@@ -921,6 +935,8 @@ class SearchWorkerResultScreenTest {
           navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
     }
 
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(1)
     // Apply Service Type filter
     composeTestRule.onNodeWithText("Service Type").performClick()
     composeTestRule.waitForIdle()
@@ -929,7 +945,7 @@ class SearchWorkerResultScreenTest {
     composeTestRule.waitForIdle()
 
     // Scroll to the "Highest Rating" button in the LazyRow
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(3)
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(3)
 
     // Apply Highest Rating filter
     composeTestRule.onNodeWithText("Highest Rating").performClick()
@@ -968,7 +984,7 @@ class SearchWorkerResultScreenTest {
                 rating = 2.9))
 
     // Provide test data to the searchViewModel
-    searchViewModel._workerProfiles.value = workers
+    searchViewModel._subCategoryWorkerProfiles.value = workers
     searchViewModel._searchSubcategory.value =
         Subcategory(
             tags =
@@ -979,6 +995,9 @@ class SearchWorkerResultScreenTest {
       SearchWorkerResult(
           navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
     }
+
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(1)
 
     // Apply Service Type filter for a tag that doesn't exist
     composeTestRule.onNodeWithText("Service Type").performClick()
@@ -999,7 +1018,8 @@ class SearchWorkerResultScreenTest {
           navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
     }
 
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(4)
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(4)
     // Click on the "Price Range" filter button
     composeTestRule.onNodeWithText("Price Range").performClick()
 
@@ -1020,7 +1040,7 @@ class SearchWorkerResultScreenTest {
             WorkerProfile(uid = "worker3", price = 3010.0, fieldOfWork = "Plumber", rating = 3.9))
 
     // Provide test data to the searchViewModel
-    searchViewModel._workerProfiles.value = workers
+    searchViewModel._subCategoryWorkerProfiles.value = workers
 
     // Set the content
     composeTestRule.setContent {
@@ -1028,7 +1048,8 @@ class SearchWorkerResultScreenTest {
           navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
     }
 
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(4)
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(4)
     // Click on the "Price Range" filter button
     composeTestRule.onNodeWithText("Price Range").performClick()
 
@@ -1060,7 +1081,7 @@ class SearchWorkerResultScreenTest {
             WorkerProfile(uid = "worker3", price = 3001.0, fieldOfWork = "Plumber", rating = 3.9))
 
     // Provide test data to the searchViewModel
-    searchViewModel._workerProfiles.value = workers
+    searchViewModel._subCategoryWorkerProfiles.value = workers
 
     // Set the content
     composeTestRule.setContent {
@@ -1068,7 +1089,8 @@ class SearchWorkerResultScreenTest {
           navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
     }
 
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(4)
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(4)
     // Click on the "Price Range" filter button
     composeTestRule.onNodeWithText("Price Range").performClick()
 
@@ -1107,7 +1129,7 @@ class SearchWorkerResultScreenTest {
                 rating = 4.0))
 
     // Provide test data to the searchViewModel
-    searchViewModel._workerProfiles.value = workers
+    searchViewModel._subCategoryWorkerProfiles.value = workers
 
     // Set the composable content
     composeTestRule.setContent {
@@ -1119,8 +1141,9 @@ class SearchWorkerResultScreenTest {
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(2)
 
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
     // Scroll to the "Location" button in the LazyRow if needed
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(1)
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(1)
 
     // Open the Location filter bottom sheet
     composeTestRule.onNodeWithText("Location").performClick()
@@ -1140,7 +1163,7 @@ class SearchWorkerResultScreenTest {
     composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(1)
 
     // Open Location filter again to clear
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(1)
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(1)
     composeTestRule.onNodeWithText("Location").performClick()
     composeTestRule.waitForIdle()
 
@@ -1178,7 +1201,7 @@ class SearchWorkerResultScreenTest {
                 location = com.arygm.quickfix.model.locations.Location(42.0, -74.5, "Work"),
                 tags = listOf("Plumber")))
 
-    searchViewModel._workerProfiles.value = workers
+    searchViewModel._subCategoryWorkerProfiles.value = workers
     searchViewModel._searchSubcategory.value =
         Subcategory(tags = listOf("Interior Painter", "Electrician", "Plumber"))
 
@@ -1191,6 +1214,8 @@ class SearchWorkerResultScreenTest {
     // Initially, all 3 workers
     composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(3)
 
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(1)
     // Apply Service Type filter = "Interior Painter"
     composeTestRule.onNodeWithText("Service Type").performClick()
     composeTestRule.waitForIdle()
@@ -1203,7 +1228,7 @@ class SearchWorkerResultScreenTest {
 
     // Apply Location filter to get even more specific (Assume "Home")
     composeTestRule
-        .onNodeWithTag("filter_buttons_row")
+        .onNodeWithTag("lazy_filter_row")
         .performScrollToIndex(1) // scroll to "Location" if needed
     composeTestRule.onNodeWithText("Location").performClick()
     composeTestRule.waitForIdle()
@@ -1215,7 +1240,7 @@ class SearchWorkerResultScreenTest {
     composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(1)
 
     // Now clear the Location filter but keep the Service Type filter
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(1)
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(1)
     composeTestRule.onNodeWithText("Location").performClick()
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithTag("resetButton").performClick()
@@ -1245,7 +1270,7 @@ class SearchWorkerResultScreenTest {
             unavailability_list = emptyList(),
             location = com.arygm.quickfix.model.locations.Location(0.0, 0.0, ""))
 
-    searchViewModel._workerProfiles.value = listOf(worker1, worker2)
+    searchViewModel._subCategoryWorkerProfiles.value = listOf(worker1, worker2)
 
     composeTestRule.setContent {
       SearchWorkerResult(
@@ -1256,7 +1281,8 @@ class SearchWorkerResultScreenTest {
     // Initially 2 workers
     composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(2)
 
-    composeTestRule.onNodeWithTag("filter_buttons_row").performScrollToIndex(4)
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(4)
     // Apply Availability filter for today at 10:00 (both should be available)
     composeTestRule.onNodeWithText("Availability").performClick()
     composeTestRule.waitForIdle()
@@ -1275,5 +1301,105 @@ class SearchWorkerResultScreenTest {
 
     // With availability cleared and no other filters applied, we should still see 2 workers
     composeTestRule.onNodeWithTag("worker_profiles_list").onChildren().assertCountEquals(2)
+  }
+
+  @Test
+  fun testTogglingRatingFilterOff() {
+    val workers =
+        listOf(
+            WorkerProfile(uid = "w1", rating = 3.0),
+            WorkerProfile(uid = "w2", rating = 4.5),
+            WorkerProfile(uid = "w3", rating = 2.0))
+
+    searchViewModel._subCategoryWorkerProfiles.value = workers
+    // Initially, no rating filter applied, workers are in initial order
+    // We'll toggle the rating filter on, then off.
+
+    composeTestRule.setContent {
+      SearchWorkerResult(
+          navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
+    }
+
+    composeTestRule.waitForIdle()
+    // Show filter buttons
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+
+    // Apply Highest Rating filter
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(3)
+    composeTestRule.onNodeWithText("Highest Rating").performClick()
+    composeTestRule.waitForIdle()
+
+    // Now workers should be sorted by rating descending: w2(4.5), w1(3.0), w3(2.0)
+    val workerNodes = composeTestRule.onNodeWithTag("worker_profiles_list").onChildren()
+    workerNodes.assertCountEquals(workers.size)
+    // Verify order by rating text
+    workerNodes[0].assert(hasAnyChild(hasText("4.5 ★", substring = true)))
+    workerNodes[1].assert(hasAnyChild(hasText("3.0 ★", substring = true)))
+    workerNodes[2].assert(hasAnyChild(hasText("2.0 ★", substring = true)))
+
+    // Click again to remove Highest Rating filter
+    composeTestRule.onNodeWithText("Highest Rating").performClick()
+    composeTestRule.waitForIdle()
+
+    // With the rating filter removed, `reapplyFilters()` is called, and no filters are applied.
+    // The default implementation should revert to the original order (the order in
+    // `_subCategoryWorkerProfiles`).
+    // Check that the initial worker (w1) is now first again.
+    val workerNodesAfterRevert = composeTestRule.onNodeWithTag("worker_profiles_list").onChildren()
+    workerNodesAfterRevert[0].assert(
+        hasAnyChild(hasText("3.0 ★", substring = true))) // w1 first again
+    workerNodesAfterRevert[1].assert(hasAnyChild(hasText("4.5 ★", substring = true)))
+    workerNodesAfterRevert[2].assert(hasAnyChild(hasText("2.0 ★", substring = true)))
+  }
+
+  @Test
+  fun testTogglingFilterButtonsVisibility() {
+    // Set some workers just so the UI loads normally
+    searchViewModel._subCategoryWorkerProfiles.value = listOf(WorkerProfile(uid = "test"))
+
+    composeTestRule.setContent {
+      SearchWorkerResult(
+          navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Initially, the lazy_filter_row might not be visible until we click the tune button
+    composeTestRule.onNodeWithTag("lazy_filter_row").assertDoesNotExist()
+
+    // Click the tune button to show filter buttons
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.onNodeWithTag("lazy_filter_row").assertIsDisplayed()
+
+    // Click the tune button again to hide filter buttons
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag("lazy_filter_row").assertDoesNotExist()
+  }
+
+  @Test
+  fun testServiceTypeSheetNotShownWhenSubcategoryIsNull() {
+    // No subcategory set
+    searchViewModel._searchSubcategory.value = null
+    // Workers to display something
+    searchViewModel._subCategoryWorkerProfiles.value = listOf(WorkerProfile(uid = "w1"))
+
+    composeTestRule.setContent {
+      SearchWorkerResult(
+          navigationActions, searchViewModel, accountViewModel, userViewModel, preferencesViewModel)
+    }
+
+    composeTestRule.waitForIdle()
+    // Show filter buttons
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+
+    // Attempt to open the Service Type filter
+    composeTestRule.onNodeWithTag("lazy_filter_row").performScrollToIndex(1)
+    composeTestRule.onNodeWithText("Service Type").performClick()
+
+    composeTestRule.waitForIdle()
+
+    // Since searchSubcategory is null, ChooseServiceTypeSheet should not appear
+    composeTestRule.onNodeWithTag("chooseServiceTypeModalSheet").assertDoesNotExist()
   }
 }

--- a/app/src/main/java/com/arygm/quickfix/model/search/SearchViewModel.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/search/SearchViewModel.kt
@@ -1,5 +1,6 @@
 package com.arygm.quickfix.model.search
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -18,9 +19,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-open class SearchViewModel(
-    private val workerProfileRepo: WorkerProfileRepositoryFirestore,
-) : ViewModel() {
+open class SearchViewModel(private val workerProfileRepo: WorkerProfileRepositoryFirestore) :
+    ViewModel() {
 
   private val _searchQuery = MutableStateFlow("")
   val searchQuery: StateFlow<String> = _searchQuery
@@ -30,6 +30,9 @@ open class SearchViewModel(
 
   val _workerProfiles = MutableStateFlow<List<WorkerProfile>>(emptyList())
   val workerProfiles: StateFlow<List<WorkerProfile>> = _workerProfiles
+
+  val _subCategoryWorkerProfiles = MutableStateFlow<List<WorkerProfile>>(emptyList())
+  val subCategoryWorkerProfiles: StateFlow<List<WorkerProfile>> = _subCategoryWorkerProfiles
 
   private val _errorMessage = MutableStateFlow<String?>(null)
   val errorMessage: StateFlow<String?> = _errorMessage
@@ -168,5 +171,16 @@ open class SearchViewModel(
               worker.location.longitude)
       distance <= maxDistance
     }
+  }
+
+  fun filterWorkersBySubcategory(fieldOfWork: String) {
+    workerProfileRepo.getProfiles(
+        onSuccess = { profiles ->
+          val workerProfiles =
+              profiles.filterIsInstance<WorkerProfile>() // Cast profiles to WorkerProfile
+          val filteredProfiles = workerProfiles.filter { it.fieldOfWork == fieldOfWork }
+          _subCategoryWorkerProfiles.value = filteredProfiles
+        },
+        onFailure = { Log.e("SearchViewModel", "Failed to fetch worker profiles.") })
   }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixLocationFilterBottomSheet.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixLocationFilterBottomSheet.kt
@@ -56,7 +56,7 @@ import com.arygm.quickfix.utils.LocationHelper
 fun QuickFixLocationFilterBottomSheet(
     showModalBottomSheet: Boolean,
     userProfile: UserProfile,
-    locationHelper: LocationHelper,
+    phoneLocation: Location,
     onApplyClick: (Location, Int) -> Unit,
     onDismissRequest: () -> Unit,
     onClearClick: () -> Unit,
@@ -236,16 +236,7 @@ fun QuickFixLocationFilterBottomSheet(
                       enabled = selectedOption.value != null,
                       onClick = {
                         if (selectedOption.value == 0) {
-                          if (locationHelper.checkPermissions()) {
-                            locationHelper.getCurrentLocation { loc ->
-                              loc?.let {
-                                val location = Location(it.latitude, it.longitude, "Phone Location")
-                                onApplyClick(location, range)
-                              }
-                            }
-                          } else {
-                            locationHelper.requestPermissions()
-                          }
+                          onApplyClick(phoneLocation, range)
                         } else {
                           onApplyClick(
                               userProfile.locations[selectedOption.value!!.minus(1)], range)
@@ -305,7 +296,7 @@ fun hehe() {
     QuickFixLocationFilterBottomSheet(
         showModalBottomSheet = showModal,
         userProfile = userProfile,
-        locationHelper = locationHelper,
+        phoneLocation = Location(200.0, 200.0, "Phone Location"),
         onApplyClick = { loc, a ->
           Log.d("Chill Guy", a.toString())
           Log.d("Chill Guy", loc.name)

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixServicesChoosing.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixServicesChoosing.kt
@@ -40,12 +40,13 @@ import com.arygm.quickfix.ui.theme.QuickFixTheme
 fun ChooseServiceTypeSheet(
     showModalBottomSheet: Boolean,
     serviceTypes: List<String>,
+    selectedServices: List<String> = emptyList<String>(),
     onApplyClick: (List<String>) -> Unit,
     onDismissRequest: () -> Unit,
     onClearClick: () -> Unit,
     clearEnabled: Boolean
 ) {
-  var selectedServices by remember { mutableStateOf(emptyList<String>()) }
+  var localSelectedServices by remember(selectedServices) { mutableStateOf(selectedServices) }
   if (showModalBottomSheet) {
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
@@ -93,18 +94,18 @@ fun ChooseServiceTypeSheet(
                       horizontalArrangement =
                           Arrangement.spacedBy(paddingHorizontal, Alignment.CenterHorizontally)) {
                         items(serviceTypes) { service ->
-                          val isSelected = service in selectedServices
+                          val isSelected = service in localSelectedServices
                           Text(
                               text = service,
                               style = MaterialTheme.typography.bodyMedium,
                               modifier =
                                   Modifier.clickable {
-                                        selectedServices =
+                                        localSelectedServices =
                                             if (isSelected) {
-                                              selectedServices -
+                                              localSelectedServices -
                                                   service // Remove if already selected
                                             } else {
-                                              selectedServices + service // Add if not selected
+                                              localSelectedServices + service // Add if not selected
                                             }
                                       }
                                       .background(
@@ -130,8 +131,9 @@ fun ChooseServiceTypeSheet(
 
                   // Apply button to confirm the selection
                   Button(
+                      enabled = localSelectedServices.isNotEmpty(),
                       onClick = {
-                        onApplyClick(selectedServices)
+                        onApplyClick(localSelectedServices)
                         onDismissRequest()
                       },
                       modifier =
@@ -156,7 +158,7 @@ fun ChooseServiceTypeSheet(
                           else colorScheme.onSecondaryContainer,
                       modifier =
                           Modifier.clickable(enabled = clearEnabled) {
-                                selectedServices = emptyList<String>()
+                                localSelectedServices = emptyList<String>()
                                 onClearClick()
                                 onDismissRequest()
                               }

--- a/app/src/main/java/com/arygm/quickfix/ui/search/ExpandableCategoryItem.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/ExpandableCategoryItem.kt
@@ -134,6 +134,7 @@ fun ExpandableCategoryItem(
                                         .clickable {
                                           searchViewModel.updateSearchQuery(it.name)
                                           searchViewModel.setSearchSubcategory(it)
+                                          searchViewModel.filterWorkersBySubcategory(it.name)
                                           navigationActions.navigateTo(Screen.SEARCH_WORKER_RESULT)
                                         },
                                 text = it.name,

--- a/app/src/main/java/com/arygm/quickfix/ui/search/SearchWorkerResult.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/search/SearchWorkerResult.kt
@@ -1,7 +1,8 @@
 package com.arygm.quickfix.ui.search
 
-import android.location.Location
 import android.util.Log
+import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -99,7 +100,8 @@ data class SearchFilterButtons(
     val onClick: () -> Unit,
     val text: String,
     val leadingIcon: ImageVector? = null,
-    val trailingIcon: ImageVector? = null
+    val trailingIcon: ImageVector? = null,
+    val applied: Boolean = false
 )
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -111,17 +113,42 @@ fun SearchWorkerResult(
     userProfileViewModel: ProfileViewModel,
     preferencesViewModel: PreferencesViewModel
 ) {
+  val locationHelper = LocationHelper(LocalContext.current, MainActivity())
+  var phoneLocation by remember {
+    mutableStateOf(com.arygm.quickfix.model.locations.Location(0.0, 0.0, "Default"))
+  }
+  var baseLocation by remember { mutableStateOf(phoneLocation) }
+  val context = LocalContext.current
+  LaunchedEffect(Unit) {
+    if (locationHelper.checkPermissions()) {
+      locationHelper.getCurrentLocation { location ->
+        if (location != null) {
+          phoneLocation =
+              com.arygm.quickfix.model.locations.Location(
+                  location.latitude, location.longitude, "Phone Location")
+          baseLocation = phoneLocation
+        } else {
+          Toast.makeText(context, "Unable to fetch location", Toast.LENGTH_SHORT).show()
+        }
+      }
+    } else {
+      Toast.makeText(context, "Enable Location In Settings", Toast.LENGTH_SHORT).show()
+    }
+  }
+
+  var showFilterButtons by remember { mutableStateOf(false) }
   var showAvailabilityBottomSheet by remember { mutableStateOf(false) }
   var showServicesBottomSheet by remember { mutableStateOf(false) }
   var showPriceRangeBottomSheet by remember { mutableStateOf(false) }
   var showLocationBottomSheet by remember { mutableStateOf(false) }
-  val workerProfiles by searchViewModel.workerProfiles.collectAsState()
+  val workerProfiles by searchViewModel.subCategoryWorkerProfiles.collectAsState()
   var filteredWorkerProfiles by remember { mutableStateOf(workerProfiles) }
 
   var availabilityFilterApplied by remember { mutableStateOf(false) }
   var servicesFilterApplied by remember { mutableStateOf(false) }
   var priceFilterApplied by remember { mutableStateOf(false) }
   var locationFilterApplied by remember { mutableStateOf(false) }
+  var ratingFilterApplied by remember { mutableStateOf(false) }
 
   var selectedDays by remember { mutableStateOf(emptyList<LocalDate>()) }
   var selectedHour by remember { mutableStateOf(0) }
@@ -156,46 +183,68 @@ fun SearchWorkerResult(
           searchViewModel.filterWorkersByDistance(updatedProfiles, selectedLocation, maxDistance)
     }
 
+    if (ratingFilterApplied) {
+      updatedProfiles = searchViewModel.sortWorkersByRating(updatedProfiles)
+    }
+
     filteredWorkerProfiles = updatedProfiles
   }
 
   val listOfButtons =
       listOf(
           SearchFilterButtons(
-              onClick = { filteredWorkerProfiles = workerProfiles },
+              onClick = {
+                filteredWorkerProfiles = workerProfiles
+                availabilityFilterApplied = false
+                priceFilterApplied = false
+                locationFilterApplied = false
+                ratingFilterApplied = false
+                servicesFilterApplied = false
+                selectedServices = emptyList()
+                baseLocation = phoneLocation
+              },
               text = "Clear",
-              leadingIcon = Icons.Default.Clear),
+              leadingIcon = Icons.Default.Clear,
+              applied = false),
           SearchFilterButtons(
               onClick = { showLocationBottomSheet = true },
               text = "Location",
               leadingIcon = Icons.Default.LocationSearching,
               trailingIcon = Icons.Default.KeyboardArrowDown,
-          ),
+              applied = locationFilterApplied),
           SearchFilterButtons(
               onClick = { showServicesBottomSheet = true },
               text = "Service Type",
               leadingIcon = Icons.Default.Handyman,
               trailingIcon = Icons.Default.KeyboardArrowDown,
-          ),
+              applied = servicesFilterApplied),
           SearchFilterButtons(
               onClick = { showAvailabilityBottomSheet = true },
               text = "Availability",
               leadingIcon = Icons.Default.CalendarMonth,
               trailingIcon = Icons.Default.KeyboardArrowDown,
-          ),
+              applied = availabilityFilterApplied),
           SearchFilterButtons(
               onClick = {
-                filteredWorkerProfiles = searchViewModel.sortWorkersByRating(filteredWorkerProfiles)
+                if (ratingFilterApplied) {
+                  ratingFilterApplied = false
+                  reapplyFilters()
+                } else {
+                  filteredWorkerProfiles =
+                      searchViewModel.sortWorkersByRating(filteredWorkerProfiles)
+                  ratingFilterApplied = true
+                }
               },
               text = "Highest Rating",
               leadingIcon = Icons.Default.WorkspacePremium,
-          ),
+              trailingIcon = if (ratingFilterApplied) Icons.Default.Clear else null,
+              applied = ratingFilterApplied),
           SearchFilterButtons(
               onClick = { showPriceRangeBottomSheet = true },
               text = "Price Range",
               leadingIcon = Icons.Default.MonetizationOn,
               trailingIcon = Icons.Default.KeyboardArrowDown,
-          ),
+              applied = priceFilterApplied),
       )
 
   // ==========================================================================//
@@ -266,7 +315,6 @@ fun SearchWorkerResult(
   var saved by remember { mutableStateOf(false) }
   val searchQuery by searchViewModel.searchQuery.collectAsState()
   val searchSubcategory by searchViewModel.searchSubcategory.collectAsState()
-  var currentLocation by remember { mutableStateOf<Location?>(null) }
 
   var userProfile = UserProfile(locations = emptyList(), announcements = emptyList(), uid = "0")
   var uid by remember { mutableStateOf("Loading...") }
@@ -279,8 +327,6 @@ fun SearchWorkerResult(
       Log.e("SearchWorkerResult", "Fetched a worker profile from a user profile repo.")
     }
   }
-
-  val locationHelper: LocationHelper = LocationHelper(LocalContext.current, MainActivity())
 
   // Wrap everything in a Box to allow overlay
   BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
@@ -339,7 +385,7 @@ fun SearchWorkerResult(
                       )
                     }
 
-                LazyRow(
+                Row(
                     modifier =
                         Modifier.fillMaxWidth()
                             .padding(top = screenHeight * 0.02f, bottom = screenHeight * 0.01f)
@@ -348,41 +394,63 @@ fun SearchWorkerResult(
                             .testTag("filter_buttons_row"),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                  items(1) {
-                    Box(modifier = Modifier.height(screenHeight * 0.05f)) {
-                      IconButton(
-                          onClick = { /* Goes to all filter screen */},
-                          modifier = Modifier.padding(bottom = screenHeight * 0.01f),
-                          content = {
-                            Icon(
-                                imageVector = Icons.Default.Tune,
-                                contentDescription = "Filter",
-                                tint = colorScheme.onBackground,
-                            )
-                          },
-                          colors =
-                              IconButtonDefaults.iconButtonColors()
-                                  .copy(containerColor = colorScheme.surface),
-                      )
-                    }
-                    Spacer(modifier = Modifier.width(10.dp))
-                  }
+                  // Tune Icon - fixed, non-scrollable
+                  IconButton(
+                      onClick = { showFilterButtons = !showFilterButtons },
+                      modifier =
+                          Modifier.padding(bottom = screenHeight * 0.01f).testTag("tuneButton"),
+                      content = {
+                        Icon(
+                            imageVector = Icons.Default.Tune,
+                            contentDescription = "Filter",
+                            tint =
+                                if (showFilterButtons) colorScheme.onPrimary
+                                else colorScheme.onBackground,
+                        )
+                      },
+                      colors =
+                          IconButtonDefaults.iconButtonColors(
+                              containerColor =
+                                  if (showFilterButtons) colorScheme.primary
+                                  else colorScheme.surface),
+                  )
 
-                  items(listOfButtons.size) { index ->
-                    QuickFixButton(
-                        buttonText = listOfButtons[index].text,
-                        onClickAction = listOfButtons[index].onClick,
-                        buttonColor = colorScheme.surface,
-                        textColor = colorScheme.onBackground,
-                        textStyle =
-                            poppinsTypography.labelSmall.copy(fontWeight = FontWeight.Medium),
-                        height = screenHeight * 0.05f,
-                        leadingIcon = listOfButtons[index].leadingIcon,
-                        trailingIcon = listOfButtons[index].trailingIcon,
-                        contentPadding =
-                            PaddingValues(vertical = 0.dp, horizontal = screenWidth * 0.02f),
-                        modifier = Modifier.testTag("filter_button_${listOfButtons[index].text}"))
-                    Spacer(modifier = Modifier.width(screenHeight * 0.01f))
+                  Spacer(modifier = Modifier.width(10.dp))
+
+                  AnimatedVisibility(visible = showFilterButtons) {
+                    LazyRow(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.testTag("lazy_filter_row")) {
+                          items(listOfButtons.size) { index ->
+                            QuickFixButton(
+                                buttonText = listOfButtons[index].text,
+                                onClickAction = listOfButtons[index].onClick,
+                                buttonColor =
+                                    if (listOfButtons[index].applied) colorScheme.primary
+                                    else colorScheme.surface,
+                                textColor =
+                                    if (listOfButtons[index].applied) colorScheme.onPrimary
+                                    else colorScheme.onBackground,
+                                textStyle =
+                                    poppinsTypography.labelSmall.copy(
+                                        fontWeight = FontWeight.Medium),
+                                height = screenHeight * 0.05f,
+                                leadingIcon = listOfButtons[index].leadingIcon,
+                                trailingIcon = listOfButtons[index].trailingIcon,
+                                leadingIconTint =
+                                    if (listOfButtons[index].applied) colorScheme.onPrimary
+                                    else colorScheme.onBackground,
+                                trailingIconTint =
+                                    if (listOfButtons[index].applied) colorScheme.onPrimary
+                                    else colorScheme.onBackground,
+                                contentPadding =
+                                    PaddingValues(
+                                        vertical = 0.dp, horizontal = screenWidth * 0.02f),
+                                modifier =
+                                    Modifier.testTag("filter_button_${listOfButtons[index].text}"))
+                            Spacer(modifier = Modifier.width(screenHeight * 0.01f))
+                          }
+                        }
                   }
                 }
 
@@ -392,21 +460,16 @@ fun SearchWorkerResult(
                     var account by remember { mutableStateOf<Account?>(null) }
                     var distance by remember { mutableStateOf<Int?>(null) }
 
-                    locationHelper.getCurrentLocation { location ->
-                      currentLocation = location
-                      location?.let {
-                        distance =
-                            profile.location
-                                ?.let { workerLocation ->
-                                  searchViewModel.calculateDistance(
-                                      workerLocation.latitude,
-                                      workerLocation.longitude,
-                                      it.latitude,
-                                      it.longitude)
-                                }
-                                ?.toInt()
-                      }
-                    }
+                    distance =
+                        profile.location
+                            ?.let { workerLocation ->
+                              searchViewModel.calculateDistance(
+                                  workerLocation.latitude,
+                                  workerLocation.longitude,
+                                  baseLocation!!.latitude,
+                                  baseLocation!!.longitude)
+                            }
+                            ?.toInt()
 
                     LaunchedEffect(profile.uid) {
                       accountViewModel.fetchUserAccount(profile.uid) { fetchedAccount: Account? ->
@@ -444,6 +507,9 @@ fun SearchWorkerResult(
         showAvailabilityBottomSheet,
         onDismissRequest = { showAvailabilityBottomSheet = false },
         onOkClick = { days, hour, minute ->
+          selectedDays = days
+          selectedHour = hour
+          selectedMinute = minute
           filteredWorkerProfiles =
               searchViewModel.filterWorkersByAvailability(
                   filteredWorkerProfiles, days, hour, minute)
@@ -451,6 +517,9 @@ fun SearchWorkerResult(
         },
         onClearClick = {
           availabilityFilterApplied = false
+          selectedDays = emptyList()
+          selectedHour = 0
+          selectedMinute = 0
           reapplyFilters()
         },
         clearEnabled = availabilityFilterApplied)
@@ -459,13 +528,16 @@ fun SearchWorkerResult(
       ChooseServiceTypeSheet(
           showServicesBottomSheet,
           it.tags,
+          selectedServices = selectedServices,
           onApplyClick = { services ->
+            selectedServices = services
             filteredWorkerProfiles =
-                searchViewModel.filterWorkersByServices(filteredWorkerProfiles, services)
+                searchViewModel.filterWorkersByServices(filteredWorkerProfiles, selectedServices)
             servicesFilterApplied = true
           },
           onDismissRequest = { showServicesBottomSheet = false },
           onClearClick = {
+            selectedServices = emptyList()
             servicesFilterApplied = false
             reapplyFilters()
           },
@@ -475,12 +547,16 @@ fun SearchWorkerResult(
     QuickFixPriceRangeBottomSheet(
         showPriceRangeBottomSheet,
         onApplyClick = { start, end ->
+          selectedPriceStart = start
+          selectedPriceEnd = end
           filteredWorkerProfiles =
               searchViewModel.filterWorkersByPriceRange(filteredWorkerProfiles, start, end)
           priceFilterApplied = true
         },
         onDismissRequest = { showPriceRangeBottomSheet = false },
         onClearClick = {
+          selectedPriceStart = 0
+          selectedPriceEnd = 0
           priceFilterApplied = false
           reapplyFilters()
         },
@@ -489,14 +565,23 @@ fun SearchWorkerResult(
     QuickFixLocationFilterBottomSheet(
         showLocationBottomSheet,
         userProfile = userProfile,
-        locationHelper = locationHelper,
+        phoneLocation = phoneLocation,
         onApplyClick = { location, max ->
+          selectedLocation = location
+          if (location == com.arygm.quickfix.model.locations.Location(0.0, 0.0, "Default")) {
+            Toast.makeText(context, "Enable Location In Settings", Toast.LENGTH_SHORT).show()
+          }
+          baseLocation = location
+          maxDistance = max
           filteredWorkerProfiles =
               searchViewModel.filterWorkersByDistance(filteredWorkerProfiles, location, max)
           locationFilterApplied = true
         },
         onDismissRequest = { showLocationBottomSheet = false },
         onClearClick = {
+          baseLocation = phoneLocation
+          selectedLocation = com.arygm.quickfix.model.locations.Location()
+          maxDistance = 0
           locationFilterApplied = false
           reapplyFilters()
         },

--- a/app/src/main/java/com/arygm/quickfix/utils/String.kt
+++ b/app/src/main/java/com/arygm/quickfix/utils/String.kt
@@ -112,3 +112,23 @@ fun screenToRoute(route: String): String {
     }
   }
 }
+
+fun inToMonth(month: Int): String {
+  return when (month) {
+    1 -> "Jan"
+    2 -> "Feb"
+    3 -> "Mar"
+    4 -> "Apr"
+    5 -> "May"
+    6 -> "Jun"
+    7 -> "Jul"
+    8 -> "Aug"
+    9 -> "Sep"
+    10 -> "Oct"
+    11 -> "Nov"
+    12 -> "Dec"
+    else -> {
+      "Default"
+    }
+  }
+}

--- a/app/src/test/java/com/arygm/quickfix/utils/StringTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/utils/StringTest.kt
@@ -197,4 +197,79 @@ class StringTest {
     val result = routeToScreen("INVALID_ROUTE")
     assertEquals(Screen.WELCOME, result)
   }
+
+  @Test
+  fun `test month 1 returns Jan`() {
+    assertEquals("Jan", inToMonth(1))
+  }
+
+  @Test
+  fun `test month 2 returns Feb`() {
+    assertEquals("Feb", inToMonth(2))
+  }
+
+  @Test
+  fun `test month 3 returns Mar`() {
+    assertEquals("Mar", inToMonth(3))
+  }
+
+  @Test
+  fun `test month 4 returns Apr`() {
+    assertEquals("Apr", inToMonth(4))
+  }
+
+  @Test
+  fun `test month 5 returns May`() {
+    assertEquals("May", inToMonth(5))
+  }
+
+  @Test
+  fun `test month 6 returns Jun`() {
+    assertEquals("Jun", inToMonth(6))
+  }
+
+  @Test
+  fun `test month 7 returns Jul`() {
+    assertEquals("Jul", inToMonth(7))
+  }
+
+  @Test
+  fun `test month 8 returns Aug`() {
+    assertEquals("Aug", inToMonth(8))
+  }
+
+  @Test
+  fun `test month 9 returns Sep`() {
+    assertEquals("Sep", inToMonth(9))
+  }
+
+  @Test
+  fun `test month 10 returns Oct`() {
+    assertEquals("Oct", inToMonth(10))
+  }
+
+  @Test
+  fun `test month 11 returns Nov`() {
+    assertEquals("Nov", inToMonth(11))
+  }
+
+  @Test
+  fun `test month 12 returns Dec`() {
+    assertEquals("Dec", inToMonth(12))
+  }
+
+  @Test
+  fun `test month 13 returns Default`() {
+    assertEquals("Default", inToMonth(13))
+  }
+
+  @Test
+  fun `test month 0 returns Default`() {
+    assertEquals("Default", inToMonth(0))
+  }
+
+  @Test
+  fun `test negative month returns Default`() {
+    assertEquals("Default", inToMonth(-5))
+  }
 }


### PR DESCRIPTION
### PR Title: Refactor SearchWorkerResult and Filter Sheets

---

### Description

This pull request introduces changes to specific components, focusing on improving modularity, usability, and user experience. Below are the detailed changes made to the code:

---

### Changes in `SearchWorkerResult`

- Refactored `SearchWorkerProfileResult`:
  - Handled the distance to workers based on selected distance in the filter, default being current phone location.
  - Made it so that now the filter row contains a tune button and a lazy row of filters, the tune button handles visibility.
  - Handled bugs with the reapply filters.
  - Made the highest rating filter clearable.
  - Changed the filter button's colors based on if they are applied or not.

---

### Changes in `ChooseServiceTypeSheet`

- Enhanced multi-service selection support:
  - Added `selectedServices` as a parameter to initialize preselected values.
  - Updated `onApplyClick` to handle multiple selected services.
  - Added a "Clear" button with `onClearClick` callback for resetting selections.
- Improved layout:
  - Used dynamic spacing and padding for better responsiveness.

---

### Changes in `QuickFixLocationFilterBottomSheet`

- Added `phoneLocation` parameter for improved location handling.
- Integrated `range` slider for filtering workers based on proximity.
- Updated `onApplyClick` to support selecting either the current phone location or a saved location.
- Refactored location list to use radio buttons for selection clarity.

---

### Checklist

- [x] Verified the functionality of updated components.
- [x] Refactored for improved readability and maintainability.

Note: Everything is in one commit because I kind of winged it, at first i only had a couple of changed in mind, but i kept on adding.