### PR TITLE
[Offline Mode] - Implement chat caching using Room

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
     alias(libs.plugins.gms)
     id("jacoco")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
@@ -198,12 +200,16 @@ dependencies {
     implementation(libs.androidx.espresso.intents)
     implementation(libs.mockk.android)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.mockk)
     androidTestImplementation(libs.mockk.android)
     androidTestImplementation(libs.mockk.agent)
     globalTestImplementation(libs.androidx.espresso.core)
+    ksp(libs.androidx.room.compiler.v250)
+
 
     // ------------- Jetpack Compose ------------------
     val composeBom = platform(libs.compose.bom)

--- a/app/src/main/java/com/arygm/quickfix/model/messaging/Chat.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/messaging/Chat.kt
@@ -1,5 +1,8 @@
 package com.arygm.quickfix.model.messaging
 
+import com.arygm.quickfix.model.offline.large.Converters
+import com.arygm.quickfix.model.offline.large.messaging.ChatEntity
+
 data class Chat(
     val chatId: String = "", // Default value
     val workeruid: String = "", // Default value
@@ -7,7 +10,16 @@ data class Chat(
     val quickFixUid: String = "", // New field for QuickFix association
     val messages: List<Message> = emptyList(), // Default empty list
     val chatStatus: ChatStatus = ChatStatus.WAITING_FOR_RESPONSE // Default to waiting for response
-)
+) {
+    fun toChatEntity(): ChatEntity {
+        return ChatEntity(
+            chatId = chatId,
+            workeruid = workeruid,
+            useruid = useruid,
+            messages = Converters().fromMessagesList(messages)
+        )
+    }
+}
 
 enum class ChatStatus {
   WAITING_FOR_RESPONSE,

--- a/app/src/main/java/com/arygm/quickfix/model/messaging/Chat.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/messaging/Chat.kt
@@ -11,14 +11,13 @@ data class Chat(
     val messages: List<Message> = emptyList(), // Default empty list
     val chatStatus: ChatStatus = ChatStatus.WAITING_FOR_RESPONSE // Default to waiting for response
 ) {
-    fun toChatEntity(): ChatEntity {
-        return ChatEntity(
-            chatId = chatId,
-            workeruid = workeruid,
-            useruid = useruid,
-            messages = Converters().fromMessagesList(messages)
-        )
-    }
+  fun toChatEntity(): ChatEntity {
+    return ChatEntity(
+        chatId = chatId,
+        workeruid = workeruid,
+        useruid = useruid,
+        messages = Converters().fromMessagesList(messages))
+  }
 }
 
 enum class ChatStatus {

--- a/app/src/main/java/com/arygm/quickfix/model/messaging/ChatRepository.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/messaging/ChatRepository.kt
@@ -5,32 +5,32 @@ interface ChatRepository {
 
   fun getRandomUid(): String
 
-  fun createChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+  suspend fun createChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
-  fun deleteChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+  suspend fun deleteChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
-  fun getChats(onSuccess: (List<Chat>) -> Unit, onFailure: (Exception) -> Unit)
+  suspend fun getChats(onSuccess: (List<Chat>) -> Unit, onFailure: (Exception) -> Unit)
 
-  fun chatExists(
+  suspend fun chatExists(
       userId: String,
       workerId: String,
       onSuccess: (Pair<Boolean, Chat?>) -> Unit,
       onFailure: (Exception) -> Unit
   )
 
-  fun sendMessage(
+  suspend fun sendMessage(
       chat: Chat,
       message: Message,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   )
 
-  fun deleteMessage(
+  suspend fun deleteMessage(
       chat: Chat,
       message: Message,
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   )
 
-  fun updateChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+  suspend fun updateChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 }

--- a/app/src/main/java/com/arygm/quickfix/model/messaging/ChatRepositoryFirestore.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/messaging/ChatRepositoryFirestore.kt
@@ -5,251 +5,263 @@ import com.arygm.quickfix.model.offline.large.messaging.ChatDao
 import com.arygm.quickfix.utils.performFirestoreOperation
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
-class ChatRepositoryFirestore(private val dao: ChatDao, private val db: FirebaseFirestore) :
-    ChatRepository {
-    private val collectionPath = "chats"
-    private val chats by lazy { db.collection(collectionPath) }
+class ChatRepositoryFirestore(
+    private val dao: ChatDao,
+    private val db: FirebaseFirestore,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) : ChatRepository {
+  private val collectionPath = "chats"
+  private val chats by lazy { db.collection(collectionPath) }
 
-    override fun init(onSuccess: () -> Unit) {
-        onSuccess()
+  override fun init(onSuccess: () -> Unit) {
+    onSuccess()
+  }
+
+  override fun getRandomUid(): String {
+    return db.collection(collectionPath).document().id
+  }
+
+  override suspend fun createChat(
+      chat: Chat,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    // Add to Room first
+    try {
+      dao.insertChat(chat.toChatEntity())
+      onSuccess()
+    } catch (e: Exception) {
+      onFailure(e)
+      return
     }
 
-    override fun getRandomUid(): String {
-        return db.collection(collectionPath).document().id
+    performFirestoreOperation(chats.document(chat.chatId).set(chat), onSuccess, onFailure)
+  }
+
+  override suspend fun deleteChat(
+      chat: Chat,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    // Delete from Room first
+    try {
+      dao.deleteChat(chat.chatId)
+      onSuccess()
+    } catch (e: Exception) {
+      onFailure(e)
+      return
     }
 
-    override suspend fun createChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-        // Add to Room first
-        try {
-            dao.insertChat(chat.toChatEntity())
-            onSuccess()
-        } catch (e: Exception) {
+    performFirestoreOperation(chats.document(chat.chatId).delete(), onSuccess, onFailure)
+  }
+
+  override suspend fun getChats(onSuccess: (List<Chat>) -> Unit, onFailure: (Exception) -> Unit) {
+    var isCached = false
+    try {
+      // Fetch chats from Room (local database)
+      val cachedChatsFlow =
+          dao.getAllChats().map { entities ->
+            entities.map { it.toChat() } // Convert each ChatEntity to Chat
+          }
+
+      // Collect the flow to get the data
+      cachedChatsFlow.collect { cachedChats ->
+        if (cachedChats.isNotEmpty()) {
+          onSuccess(cachedChats)
+          isCached = true
+          return@collect
+        }
+      }
+    } catch (localError: Exception) {
+      Log.e("ChatRepositoryFirestore", "Error fetching local chats: ${localError.message}")
+    }
+    if (isCached) return
+    chats
+        .get()
+        .addOnSuccessListener { result ->
+          try {
+            val chats = result.documents.mapNotNull { document -> documentToChat(document) }
+            Log.d("FirebaseData", "Chats fetched: $chats")
+            CoroutineScope(dispatcher).launch {
+              chats.forEach { chat -> dao.insertChat(chat.toChatEntity()) }
+            }
+            onSuccess(chats)
+          } catch (e: Exception) {
+            Log.e("FirebaseError", "Error deserializing chats: ${e.message}")
             onFailure(e)
-            return
+          }
         }
+        .addOnFailureListener { error ->
+          Log.e("FirebaseError", "Error fetching chats: ${error.message}")
+          onFailure(error)
+        }
+  }
 
-        performFirestoreOperation(chats.document(chat.chatId).set(chat), onSuccess, onFailure)
+  override suspend fun chatExists(
+      userId: String,
+      workerId: String,
+      onSuccess: (Pair<Boolean, Chat?>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    try {
+      // Check locally first
+      val cachedChat = dao.getChatById(userId + workerId)?.toChat()
+      if (cachedChat != null) {
+        onSuccess(Pair(true, cachedChat))
+        return
+      }
+    } catch (localError: Exception) {
+      Log.e("ChatRepositoryFirestore", "Error checking chat locally: ${localError.message}")
     }
 
-    override suspend fun deleteChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-        // Delete from Room first
-        try {
-            dao.deleteChat(chat.chatId)
-            onSuccess()
-        } catch (e: Exception) {
-            onFailure(e)
-            return
+    // Fallback to Firestore if local check fails
+    chats
+        .whereEqualTo("chatId", userId + workerId)
+        .get()
+        .addOnSuccessListener { result ->
+          val chat = result.toObjects(Chat::class.java).firstOrNull()
+          onSuccess(Pair(chat != null, chat))
         }
+        .addOnFailureListener { onFailure(it) }
+  }
 
-        performFirestoreOperation(chats.document(chat.chatId).delete(), onSuccess, onFailure)
+  override suspend fun sendMessage(
+      chat: Chat,
+      message: Message,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    Log.e("ChatRepositoryFirestore", "sendMessage: $message")
+    Log.e("ChatRepositoryFirestore", "sendChat: $chat")
+    try {
+      val updatedMessages = chat.messages + message
+      val updatedChat =
+          Chat(
+              chat.chatId,
+              chat.workeruid,
+              chat.useruid,
+              chat.quickFixUid,
+              updatedMessages,
+              chat.chatStatus)
+      dao.insertChat(updatedChat.toChatEntity())
+    } catch (e: Exception) {
+      onFailure(e)
+      return
     }
 
-    override suspend fun getChats(onSuccess: (List<Chat>) -> Unit, onFailure: (Exception) -> Unit) {
-        try {
-            // Fetch chats from Room (local database)
-            val cachedChatsFlow = dao.getAllChats().map { entities ->
-                entities.map { it.toChat() } // Convert each ChatEntity to Chat
-            }
+    val messageData =
+        mapOf(
+            "messageId" to message.messageId,
+            "senderId" to message.senderId,
+            "content" to message.content,
+            "timestamp" to message.timestamp)
 
-            // Collect the flow to get the data
-            cachedChatsFlow.collect { cachedChats ->
-                if (cachedChats.isNotEmpty()) {
-                    onSuccess(cachedChats)
-                    return@collect
-                }
-            }
-        } catch (localError: Exception) {
-            Log.e("ChatRepositoryFirestore", "Error fetching local chats: ${localError.message}")
+    chats
+        .document(chat.chatId)
+        .update("messages", com.google.firebase.firestore.FieldValue.arrayUnion(messageData))
+        .addOnSuccessListener {
+          Log.d("ChatRepositoryFirestore", "Message added successfully!")
+          onSuccess()
         }
-        chats
-            .get()
-            .addOnSuccessListener { result ->
-                try {
-                    val chats = result.documents.mapNotNull { document -> documentToChat(document) }
-                    Log.d("FirebaseData", "Chats fetched: $chats")
-                    CoroutineScope(Dispatchers.IO).launch {
-                        chats.forEach { chat ->
-                            dao.insertChat(chat.toChatEntity())
-                        }
-                    }
-                    onSuccess(chats)
-                } catch (e: Exception) {
-                    Log.e("FirebaseError", "Error deserializing chats: ${e.message}")
-                    onFailure(e)
-                }
-            }
-            .addOnFailureListener { error ->
-                Log.e("FirebaseError", "Error fetching chats: ${error.message}")
-                onFailure(error)
-            }
+        .addOnFailureListener { exception ->
+          Log.e("ChatRepositoryFirestore", "Failed to add message: ${exception.message}")
+          onFailure(exception)
+        }
+  }
+
+  override suspend fun deleteMessage(
+      chat: Chat,
+      message: Message,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    // Delete from Room first
+    try {
+      val updatedMessages = chat.messages.filter { it.messageId != message.messageId }
+      val updatedChat =
+          Chat(
+              chat.chatId,
+              chat.workeruid,
+              chat.useruid,
+              chat.quickFixUid,
+              updatedMessages,
+              chat.chatStatus)
+      dao.insertChat(updatedChat.toChatEntity())
+      onSuccess()
+    } catch (e: Exception) {
+      onFailure(e)
+      return
     }
 
-    override suspend fun chatExists(
-        userId: String,
-        workerId: String,
-        onSuccess: (Pair<Boolean, Chat?>) -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        try {
-            // Check locally first
-            val cachedChat = dao.getChatById(userId + workerId)?.toChat()
-            if (cachedChat != null) {
-                onSuccess(Pair(true, cachedChat))
-                return
+    performFirestoreOperation(
+        chats.document(chat.chatId).collection("messages").document(message.messageId).delete(),
+        onSuccess,
+        onFailure)
+  }
+
+  override suspend fun updateChat(
+      chat: Chat,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    // Update Room first
+    try {
+      dao.insertChat(chat.toChatEntity())
+      onSuccess()
+    } catch (e: Exception) {
+      onFailure(e)
+      return
+    }
+
+    // Sync to Firestore
+    performFirestoreOperation(chats.document(chat.chatId).set(chat), onSuccess, onFailure)
+  }
+
+  private fun documentToChat(document: DocumentSnapshot): Chat? {
+    return try {
+      val chatId = document.getString("chatId") ?: return null
+      val workerUid = document.getString("workeruid") ?: return null
+      val userUid = document.getString("useruid") ?: return null
+      val quickFixUid =
+          document.getString("quickFixUid") ?: return null // Handle optional QuickFixUid
+      val chatStatusString =
+          document.getString("chatStatus") ?: ChatStatus.WAITING_FOR_RESPONSE.name
+      val chatStatus = ChatStatus.valueOf(chatStatusString)
+      val messagesList = document.get("messages") as? List<Map<String, Any>> ?: emptyList()
+
+      val messages =
+          messagesList.mapNotNull { messageData ->
+            try {
+              Message(
+                  messageId = messageData["messageId"] as? String ?: "",
+                  senderId = messageData["senderId"] as? String ?: "",
+                  content = messageData["content"] as? String ?: "",
+                  timestamp =
+                      messageData["timestamp"] as? com.google.firebase.Timestamp
+                          ?: com.google.firebase.Timestamp.now())
+            } catch (e: Exception) {
+              Log.e("FirebaseError", "Error deserializing message: ${e.message}")
+              null
             }
-        } catch (localError: Exception) {
-            Log.e("ChatRepositoryFirestore", "Error checking chat locally: ${localError.message}")
-        }
+          }
 
-        // Fallback to Firestore if local check fails
-        chats.whereEqualTo("chatId", userId + workerId)
-            .get()
-            .addOnSuccessListener { result ->
-                val chat = result.toObjects(Chat::class.java).firstOrNull()
-                onSuccess(Pair(chat != null, chat))
-            }
-            .addOnFailureListener { onFailure(it) }
+      Chat(
+          chatId = chatId,
+          workeruid = workerUid,
+          useruid = userUid,
+          quickFixUid = quickFixUid,
+          messages = messages,
+          chatStatus = chatStatus,
+      )
+    } catch (e: Exception) {
+      Log.e("FirebaseError", "Error converting document to Chat: ${e.message}")
+      null
     }
-
-    override suspend fun sendMessage(
-        chat: Chat,
-        message: Message,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        Log.e("ChatRepositoryFirestore", "sendMessage: $message")
-        Log.e("ChatRepositoryFirestore", "sendChat: $chat")
-        try {
-            val updatedMessages = chat.messages + message
-            val updatedChat = Chat(
-                chat.chatId,
-                chat.workeruid,
-                chat.useruid,
-                chat.quickFixUid,
-                updatedMessages,
-                chat.chatStatus
-            )
-            dao.insertChat(updatedChat.toChatEntity())
-        } catch (e: Exception) {
-            onFailure(e)
-            return
-        }
-
-        val messageData =
-            mapOf(
-                "messageId" to message.messageId,
-                "senderId" to message.senderId,
-                "content" to message.content,
-                "timestamp" to message.timestamp
-            )
-
-        chats
-            .document(chat.chatId)
-            .update("messages", com.google.firebase.firestore.FieldValue.arrayUnion(messageData))
-            .addOnSuccessListener {
-                Log.d("ChatRepositoryFirestore", "Message added successfully!")
-                onSuccess()
-            }
-            .addOnFailureListener { exception ->
-                Log.e("ChatRepositoryFirestore", "Failed to add message: ${exception.message}")
-                onFailure(exception)
-            }
-    }
-
-    override suspend fun deleteMessage(
-        chat: Chat,
-        message: Message,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        // Delete from Room first
-        try {
-            val updatedMessages = chat.messages.filter { it.messageId != message.messageId }
-            val updatedChat = Chat(
-                chat.chatId,
-                chat.workeruid,
-                chat.useruid,
-                chat.quickFixUid,
-                updatedMessages,
-                chat.chatStatus
-            )
-            dao.insertChat(updatedChat.toChatEntity())
-            onSuccess()
-        } catch (e: Exception) {
-            onFailure(e)
-            return
-        }
-
-        performFirestoreOperation(
-            chats.document(chat.chatId).collection("messages").document(message.messageId).delete(),
-            onSuccess,
-            onFailure
-        )
-    }
-
-    override suspend fun updateChat(
-        chat: Chat,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        // Update Room first
-        try {
-            dao.insertChat(chat.toChatEntity())
-            onSuccess()
-        } catch (e: Exception) {
-            onFailure(e)
-            return
-        }
-
-        // Sync to Firestore
-        performFirestoreOperation(chats.document(chat.chatId).set(chat), onSuccess, onFailure)
-    }
-
-    private fun documentToChat(document: DocumentSnapshot): Chat? {
-        return try {
-            val chatId = document.getString("chatId") ?: return null
-            val workerUid = document.getString("workeruid") ?: return null
-            val userUid = document.getString("useruid") ?: return null
-            val quickFixUid =
-                document.getString("quickFixUid") ?: return null // Handle optional QuickFixUid
-            val chatStatusString =
-                document.getString("chatStatus") ?: ChatStatus.WAITING_FOR_RESPONSE.name
-            val chatStatus = ChatStatus.valueOf(chatStatusString)
-            val messagesList = document.get("messages") as? List<Map<String, Any>> ?: emptyList()
-
-            val messages =
-                messagesList.mapNotNull { messageData ->
-                    try {
-                        Message(
-                            messageId = messageData["messageId"] as? String ?: "",
-                            senderId = messageData["senderId"] as? String ?: "",
-                            content = messageData["content"] as? String ?: "",
-                            timestamp =
-                            messageData["timestamp"] as? com.google.firebase.Timestamp
-                                ?: com.google.firebase.Timestamp.now()
-                        )
-                    } catch (e: Exception) {
-                        Log.e("FirebaseError", "Error deserializing message: ${e.message}")
-                        null
-                    }
-                }
-
-            Chat(
-                chatId = chatId,
-                workeruid = workerUid,
-                useruid = userUid,
-                quickFixUid = quickFixUid,
-                messages = messages,
-                chatStatus = chatStatus,
-            )
-        } catch (e: Exception) {
-            Log.e("FirebaseError", "Error converting document to Chat: ${e.message}")
-            null
-        }
-    }
+  }
 }

--- a/app/src/main/java/com/arygm/quickfix/model/messaging/ChatRepositoryFirestore.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/messaging/ChatRepositoryFirestore.kt
@@ -1,150 +1,255 @@
 package com.arygm.quickfix.model.messaging
 
 import android.util.Log
+import com.arygm.quickfix.model.offline.large.messaging.ChatDao
 import com.arygm.quickfix.utils.performFirestoreOperation
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
-class ChatRepositoryFirestore(private val db: FirebaseFirestore) : ChatRepository {
-  private val collectionPath = "chats"
-  private val chats by lazy { db.collection(collectionPath) }
+class ChatRepositoryFirestore(private val dao: ChatDao, private val db: FirebaseFirestore) :
+    ChatRepository {
+    private val collectionPath = "chats"
+    private val chats by lazy { db.collection(collectionPath) }
 
-  override fun init(onSuccess: () -> Unit) {
-    onSuccess()
-  }
-
-  override fun getRandomUid(): String {
-    return db.collection(collectionPath).document().id
-  }
-
-  override fun createChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    performFirestoreOperation(chats.document(chat.chatId).set(chat), onSuccess, onFailure)
-  }
-
-  override fun deleteChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    performFirestoreOperation(chats.document(chat.chatId).delete(), onSuccess, onFailure)
-  }
-
-  override fun getChats(onSuccess: (List<Chat>) -> Unit, onFailure: (Exception) -> Unit) {
-    chats
-        .get()
-        .addOnSuccessListener { result ->
-          try {
-            val chats = result.documents.mapNotNull { document -> documentToChat(document) }
-            Log.d("FirebaseData", "Chats fetched: $chats")
-            onSuccess(chats)
-          } catch (e: Exception) {
-            Log.e("FirebaseError", "Error deserializing chats: ${e.message}")
-            onFailure(e)
-          }
-        }
-        .addOnFailureListener { error ->
-          Log.e("FirebaseError", "Error fetching chats: ${error.message}")
-          onFailure(error)
-        }
-  }
-
-  override fun chatExists(
-      userId: String,
-      workerId: String,
-      onSuccess: (Pair<Boolean, Chat?>) -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    chats
-        .whereEqualTo("chatId", userId + workerId)
-        .get()
-        .addOnSuccessListener { result ->
-          val chat = result.toObjects(Chat::class.java).firstOrNull()
-          onSuccess(Pair(result.size() > 0, chat))
-        }
-        .addOnFailureListener { onFailure(it) }
-  }
-
-  override fun sendMessage(
-      chat: Chat,
-      message: Message,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    Log.e("ChatRepositoryFirestore", "sendMessage: $message")
-    Log.e("ChatRepositoryFirestore", "sendChat: $chat")
-
-    val messageData =
-        mapOf(
-            "messageId" to message.messageId,
-            "senderId" to message.senderId,
-            "content" to message.content,
-            "timestamp" to message.timestamp)
-
-    chats
-        .document(chat.chatId)
-        .update("messages", com.google.firebase.firestore.FieldValue.arrayUnion(messageData))
-        .addOnSuccessListener {
-          Log.d("ChatRepositoryFirestore", "Message added successfully!")
-          onSuccess()
-        }
-        .addOnFailureListener { exception ->
-          Log.e("ChatRepositoryFirestore", "Failed to add message: ${exception.message}")
-          onFailure(exception)
-        }
-  }
-
-  override fun deleteMessage(
-      chat: Chat,
-      message: Message,
-      onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    performFirestoreOperation(
-        chats.document(chat.chatId).collection("messages").document(message.messageId).delete(),
-        onSuccess,
-        onFailure)
-  }
-
-  override fun updateChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    performFirestoreOperation(
-        db.collection(collectionPath).document(chat.chatId).set(chat), onSuccess, onFailure)
-  }
-
-  private fun documentToChat(document: DocumentSnapshot): Chat? {
-    return try {
-      val chatId = document.getString("chatId") ?: return null
-      val workerUid = document.getString("workeruid") ?: return null
-      val userUid = document.getString("useruid") ?: return null
-      val quickFixUid =
-          document.getString("quickFixUid") ?: return null // Handle optional QuickFixUid
-      val chatStatusString =
-          document.getString("chatStatus") ?: ChatStatus.WAITING_FOR_RESPONSE.name
-      val chatStatus = ChatStatus.valueOf(chatStatusString)
-      val messagesList = document.get("messages") as? List<Map<String, Any>> ?: emptyList()
-
-      val messages =
-          messagesList.mapNotNull { messageData ->
-            try {
-              Message(
-                  messageId = messageData["messageId"] as? String ?: "",
-                  senderId = messageData["senderId"] as? String ?: "",
-                  content = messageData["content"] as? String ?: "",
-                  timestamp =
-                      messageData["timestamp"] as? com.google.firebase.Timestamp
-                          ?: com.google.firebase.Timestamp.now())
-            } catch (e: Exception) {
-              Log.e("FirebaseError", "Error deserializing message: ${e.message}")
-              null
-            }
-          }
-
-      Chat(
-          chatId = chatId,
-          workeruid = workerUid,
-          useruid = userUid,
-          quickFixUid = quickFixUid,
-          messages = messages,
-          chatStatus = chatStatus,
-      )
-    } catch (e: Exception) {
-      Log.e("FirebaseError", "Error converting document to Chat: ${e.message}")
-      null
+    override fun init(onSuccess: () -> Unit) {
+        onSuccess()
     }
-  }
+
+    override fun getRandomUid(): String {
+        return db.collection(collectionPath).document().id
+    }
+
+    override suspend fun createChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+        // Add to Room first
+        try {
+            dao.insertChat(chat.toChatEntity())
+            onSuccess()
+        } catch (e: Exception) {
+            onFailure(e)
+            return
+        }
+
+        performFirestoreOperation(chats.document(chat.chatId).set(chat), onSuccess, onFailure)
+    }
+
+    override suspend fun deleteChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+        // Delete from Room first
+        try {
+            dao.deleteChat(chat.chatId)
+            onSuccess()
+        } catch (e: Exception) {
+            onFailure(e)
+            return
+        }
+
+        performFirestoreOperation(chats.document(chat.chatId).delete(), onSuccess, onFailure)
+    }
+
+    override suspend fun getChats(onSuccess: (List<Chat>) -> Unit, onFailure: (Exception) -> Unit) {
+        try {
+            // Fetch chats from Room (local database)
+            val cachedChatsFlow = dao.getAllChats().map { entities ->
+                entities.map { it.toChat() } // Convert each ChatEntity to Chat
+            }
+
+            // Collect the flow to get the data
+            cachedChatsFlow.collect { cachedChats ->
+                if (cachedChats.isNotEmpty()) {
+                    onSuccess(cachedChats)
+                    return@collect
+                }
+            }
+        } catch (localError: Exception) {
+            Log.e("ChatRepositoryFirestore", "Error fetching local chats: ${localError.message}")
+        }
+        chats
+            .get()
+            .addOnSuccessListener { result ->
+                try {
+                    val chats = result.documents.mapNotNull { document -> documentToChat(document) }
+                    Log.d("FirebaseData", "Chats fetched: $chats")
+                    CoroutineScope(Dispatchers.IO).launch {
+                        chats.forEach { chat ->
+                            dao.insertChat(chat.toChatEntity())
+                        }
+                    }
+                    onSuccess(chats)
+                } catch (e: Exception) {
+                    Log.e("FirebaseError", "Error deserializing chats: ${e.message}")
+                    onFailure(e)
+                }
+            }
+            .addOnFailureListener { error ->
+                Log.e("FirebaseError", "Error fetching chats: ${error.message}")
+                onFailure(error)
+            }
+    }
+
+    override suspend fun chatExists(
+        userId: String,
+        workerId: String,
+        onSuccess: (Pair<Boolean, Chat?>) -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        try {
+            // Check locally first
+            val cachedChat = dao.getChatById(userId + workerId)?.toChat()
+            if (cachedChat != null) {
+                onSuccess(Pair(true, cachedChat))
+                return
+            }
+        } catch (localError: Exception) {
+            Log.e("ChatRepositoryFirestore", "Error checking chat locally: ${localError.message}")
+        }
+
+        // Fallback to Firestore if local check fails
+        chats.whereEqualTo("chatId", userId + workerId)
+            .get()
+            .addOnSuccessListener { result ->
+                val chat = result.toObjects(Chat::class.java).firstOrNull()
+                onSuccess(Pair(chat != null, chat))
+            }
+            .addOnFailureListener { onFailure(it) }
+    }
+
+    override suspend fun sendMessage(
+        chat: Chat,
+        message: Message,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        Log.e("ChatRepositoryFirestore", "sendMessage: $message")
+        Log.e("ChatRepositoryFirestore", "sendChat: $chat")
+        try {
+            val updatedMessages = chat.messages + message
+            val updatedChat = Chat(
+                chat.chatId,
+                chat.workeruid,
+                chat.useruid,
+                chat.quickFixUid,
+                updatedMessages,
+                chat.chatStatus
+            )
+            dao.insertChat(updatedChat.toChatEntity())
+        } catch (e: Exception) {
+            onFailure(e)
+            return
+        }
+
+        val messageData =
+            mapOf(
+                "messageId" to message.messageId,
+                "senderId" to message.senderId,
+                "content" to message.content,
+                "timestamp" to message.timestamp
+            )
+
+        chats
+            .document(chat.chatId)
+            .update("messages", com.google.firebase.firestore.FieldValue.arrayUnion(messageData))
+            .addOnSuccessListener {
+                Log.d("ChatRepositoryFirestore", "Message added successfully!")
+                onSuccess()
+            }
+            .addOnFailureListener { exception ->
+                Log.e("ChatRepositoryFirestore", "Failed to add message: ${exception.message}")
+                onFailure(exception)
+            }
+    }
+
+    override suspend fun deleteMessage(
+        chat: Chat,
+        message: Message,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        // Delete from Room first
+        try {
+            val updatedMessages = chat.messages.filter { it.messageId != message.messageId }
+            val updatedChat = Chat(
+                chat.chatId,
+                chat.workeruid,
+                chat.useruid,
+                chat.quickFixUid,
+                updatedMessages,
+                chat.chatStatus
+            )
+            dao.insertChat(updatedChat.toChatEntity())
+            onSuccess()
+        } catch (e: Exception) {
+            onFailure(e)
+            return
+        }
+
+        performFirestoreOperation(
+            chats.document(chat.chatId).collection("messages").document(message.messageId).delete(),
+            onSuccess,
+            onFailure
+        )
+    }
+
+    override suspend fun updateChat(
+        chat: Chat,
+        onSuccess: () -> Unit,
+        onFailure: (Exception) -> Unit
+    ) {
+        // Update Room first
+        try {
+            dao.insertChat(chat.toChatEntity())
+            onSuccess()
+        } catch (e: Exception) {
+            onFailure(e)
+            return
+        }
+
+        // Sync to Firestore
+        performFirestoreOperation(chats.document(chat.chatId).set(chat), onSuccess, onFailure)
+    }
+
+    private fun documentToChat(document: DocumentSnapshot): Chat? {
+        return try {
+            val chatId = document.getString("chatId") ?: return null
+            val workerUid = document.getString("workeruid") ?: return null
+            val userUid = document.getString("useruid") ?: return null
+            val quickFixUid =
+                document.getString("quickFixUid") ?: return null // Handle optional QuickFixUid
+            val chatStatusString =
+                document.getString("chatStatus") ?: ChatStatus.WAITING_FOR_RESPONSE.name
+            val chatStatus = ChatStatus.valueOf(chatStatusString)
+            val messagesList = document.get("messages") as? List<Map<String, Any>> ?: emptyList()
+
+            val messages =
+                messagesList.mapNotNull { messageData ->
+                    try {
+                        Message(
+                            messageId = messageData["messageId"] as? String ?: "",
+                            senderId = messageData["senderId"] as? String ?: "",
+                            content = messageData["content"] as? String ?: "",
+                            timestamp =
+                            messageData["timestamp"] as? com.google.firebase.Timestamp
+                                ?: com.google.firebase.Timestamp.now()
+                        )
+                    } catch (e: Exception) {
+                        Log.e("FirebaseError", "Error deserializing message: ${e.message}")
+                        null
+                    }
+                }
+
+            Chat(
+                chatId = chatId,
+                workeruid = workerUid,
+                useruid = userUid,
+                quickFixUid = quickFixUid,
+                messages = messages,
+                chatStatus = chatStatus,
+            )
+        } catch (e: Exception) {
+            Log.e("FirebaseError", "Error converting document to Chat: ${e.message}")
+            null
+        }
+    }
 }

--- a/app/src/main/java/com/arygm/quickfix/model/messaging/ChatViewModel.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/messaging/ChatViewModel.kt
@@ -1,114 +1,124 @@
 package com.arygm.quickfix.model.messaging
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.arygm.quickfix.model.offline.large.QuickFixRoomDatabase
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class ChatViewModel(private val repository: ChatRepository) : ViewModel() {
 
-  private val chats_ = MutableStateFlow<List<Chat>>(emptyList())
-  val chats: StateFlow<List<Chat>> = chats_.asStateFlow()
-  private val selectedChat_ = MutableStateFlow<Chat?>(null)
-  val selectedChat: StateFlow<Chat?> = selectedChat_.asStateFlow()
+    private val _chats = MutableStateFlow<List<Chat>>(emptyList())
+    val chats: StateFlow<List<Chat>> = _chats.asStateFlow()
+    private val _selectedChat = MutableStateFlow<Chat?>(null)
+    val selectedChat: StateFlow<Chat?> = _selectedChat.asStateFlow()
+    private val viewModelScope = CoroutineScope(Dispatchers.IO)
+    suspend fun getChats() {
+        repository.getChats(
+            onSuccess = { _chats.value = it },
+            onFailure = { e -> Log.e("ChatViewModel", "Failed to fetch chats: ${e.message}") })
+    }
 
-  fun getChats() {
-    repository.getChats(
-        onSuccess = { chats_.value = it },
-        onFailure = { e -> Log.e("ChatViewModel", "Failed to fetch chats: ${e.message}") })
-  }
+    companion object {
+        fun Factory(context: Context): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return ChatViewModel(
+                        ChatRepositoryFirestore(
+                            QuickFixRoomDatabase.getInstance(context).chatDao(),
+                            Firebase.firestore
+                        )
+                    ) as T
+                }
+            }
+    }
 
-  companion object {
-    val Factory: ViewModelProvider.Factory =
-        object : ViewModelProvider.Factory {
-          @Suppress("UNCHECKED_CAST")
-          override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return ChatViewModel(ChatRepositoryFirestore(Firebase.firestore)) as T
-          }
-        }
-  }
+    suspend fun addChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+        repository.createChat(
+            chat = chat,
+            onSuccess = {
+                viewModelScope.launch { getChats() }
+                onSuccess()
+            },
+            onFailure = { e ->
+                Log.e("ChatViewModel", "Failed to add chat: ${e.message}")
+                onFailure(e)
+            })
+    }
 
-  fun addChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    repository.createChat(
-        chat = chat,
-        onSuccess = {
-          getChats()
-          onSuccess()
-        },
-        onFailure = { e ->
-          Log.e("ChatViewModel", "Failed to add chat: ${e.message}")
-          onFailure(e)
-        })
-  }
+    suspend fun deleteChat(chat: Chat) {
+        repository.deleteChat(
+            chat = chat,
+            onSuccess = { viewModelScope.launch { getChats() } },
+            onFailure = { e -> Log.e("ChatViewModel", "Failed to delete chat: ${e.message}") })
+    }
 
-  fun deleteChat(chat: Chat) {
-    repository.deleteChat(
-        chat = chat,
-        onSuccess = { getChats() },
-        onFailure = { e -> Log.e("ChatViewModel", "Failed to delete chat: ${e.message}") })
-  }
+    suspend fun chatExists(userId: String, workerId: String, onResult: (Boolean, Chat?) -> Unit) {
+        repository.chatExists(
+            userId = userId,
+            workerId = workerId,
+            onSuccess = { (exists, chat) ->
+                if (exists) {
+                    Log.d("ChatCheck", "Chat between this user and worker exists")
+                    onResult(true, chat)
+                } else {
+                    Log.d("ChatCheck", "Chat between this user and worker does not exist")
+                    onResult(false, null)
+                }
+            },
+            onFailure = { e ->
+                Log.e("ChatViewModel", "Failed to check if chat exists: ${e.message}")
+                onResult(false, null)
+            })
+    }
 
-  fun chatExists(userId: String, workerId: String, onResult: (Boolean, Chat?) -> Unit) {
-    repository.chatExists(
-        userId = userId,
-        workerId = workerId,
-        onSuccess = { (exists, chat) ->
-          if (exists) {
-            Log.d("ChatCheck", "Chat between this user and worker exists")
-            onResult(true, chat)
-          } else {
-            Log.d("ChatCheck", "Chat between this user and worker does not exist")
-            onResult(false, null)
-          }
-        },
-        onFailure = { e ->
-          Log.e("ChatViewModel", "Failed to check if chat exists: ${e.message}")
-          onResult(false, null)
-        })
-  }
+    suspend fun sendMessage(chat: Chat, message: Message) {
+        repository.sendMessage(
+            chat = chat,
+            message = message,
+            onSuccess = { viewModelScope.launch { getChats() } },
+            onFailure = { e -> Log.e("ChatViewModel", "Failed to send message: ${e.message}") })
+    }
 
-  fun sendMessage(chat: Chat, message: Message) {
-    repository.sendMessage(
-        chat = chat,
-        message = message,
-        onSuccess = { getChats() },
-        onFailure = { e -> Log.e("ChatViewModel", "Failed to send message: ${e.message}") })
-  }
+    suspend fun deleteMessage(chat: Chat, message: Message) {
+        repository.deleteMessage(
+            chat = chat,
+            message = message,
+            onSuccess = { viewModelScope.launch { getChats() } },
+            onFailure = { e -> Log.e("ChatViewModel", "Failed to delete message: ${e.message}") })
+    }
 
-  fun deleteMessage(chat: Chat, message: Message) {
-    repository.deleteMessage(
-        chat = chat,
-        message = message,
-        onSuccess = { getChats() },
-        onFailure = { e -> Log.e("ChatViewModel", "Failed to delete message: ${e.message}") })
-  }
+    fun getRandomUid(): String {
+        return repository.getRandomUid()
+    }
 
-  fun getRandomUid(): String {
-    return repository.getRandomUid()
-  }
+    suspend fun updateChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+        repository.updateChat(
+            chat = chat,
+            onSuccess = {
+                viewModelScope.launch { getChats() }
+                onSuccess()
+            },
+            onFailure = { e ->
+                Log.e("ChatViewModel", "Failed to update chat: ${e.message}")
+                onFailure(e)
+            })
+    }
 
-  fun updateChat(chat: Chat, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-    repository.updateChat(
-        chat = chat,
-        onSuccess = {
-          getChats()
-          onSuccess()
-        },
-        onFailure = { e ->
-          Log.e("ChatViewModel", "Failed to update chat: ${e.message}")
-          onFailure(e)
-        })
-  }
+    fun selectChat(chat: Chat) {
+        _selectedChat.value = chat
+    }
 
-  fun selectChat(chat: Chat) {
-    selectedChat_.value = chat
-  }
-
-  fun clearSelectedChat() {
-    selectedChat_.value = null
-  }
+    fun clearSelectedChat() {
+        _selectedChat.value = null
+    }
 }

--- a/app/src/main/java/com/arygm/quickfix/model/offline/large/Converters.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/offline/large/Converters.kt
@@ -1,0 +1,21 @@
+package com.arygm.quickfix.model.offline.large
+
+import androidx.room.TypeConverter
+import com.arygm.quickfix.model.messaging.Message
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+class Converters {
+    private val gson = Gson()
+
+    @TypeConverter
+    fun fromMessagesList(messages: List<Message>): String {
+        return gson.toJson(messages)
+    }
+
+    @TypeConverter
+    fun toMessagesList(messagesJson: String): List<Message> {
+        val type = object : TypeToken<List<Message>>() {}.type
+        return gson.fromJson(messagesJson, type)
+    }
+}

--- a/app/src/main/java/com/arygm/quickfix/model/offline/large/Converters.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/offline/large/Converters.kt
@@ -6,16 +6,16 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
 class Converters {
-    private val gson = Gson()
+  private val gson = Gson()
 
-    @TypeConverter
-    fun fromMessagesList(messages: List<Message>): String {
-        return gson.toJson(messages)
-    }
+  @TypeConverter
+  fun fromMessagesList(messages: List<Message>): String {
+    return gson.toJson(messages)
+  }
 
-    @TypeConverter
-    fun toMessagesList(messagesJson: String): List<Message> {
-        val type = object : TypeToken<List<Message>>() {}.type
-        return gson.fromJson(messagesJson, type)
-    }
+  @TypeConverter
+  fun toMessagesList(messagesJson: String): List<Message> {
+    val type = object : TypeToken<List<Message>>() {}.type
+    return gson.fromJson(messagesJson, type)
+  }
 }

--- a/app/src/main/java/com/arygm/quickfix/model/offline/large/QuickFixRoomDatabase.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/offline/large/QuickFixRoomDatabase.kt
@@ -11,22 +11,20 @@ import com.arygm.quickfix.model.offline.large.messaging.ChatEntity
 @Database(entities = [ChatEntity::class], version = 1)
 @TypeConverters(Converters::class)
 abstract class QuickFixRoomDatabase : RoomDatabase() {
-    abstract fun chatDao(): ChatDao
+  abstract fun chatDao(): ChatDao
 
-    companion object {
-        @Volatile
-        private var INSTANCE: QuickFixRoomDatabase? = null
+  companion object {
+    @Volatile private var INSTANCE: QuickFixRoomDatabase? = null
 
-        fun getInstance(context: Context): QuickFixRoomDatabase {
-            return INSTANCE ?: synchronized(this) {
-                Room.databaseBuilder(
-                    context.applicationContext,
-                    QuickFixRoomDatabase::class.java,
-                    "app_database"
-                )
-                    .fallbackToDestructiveMigration() // Remove for production, add migrations instead
-                    .build().also { INSTANCE = it }
-            }
-        }
+    fun getInstance(context: Context): QuickFixRoomDatabase {
+      return INSTANCE
+          ?: synchronized(this) {
+            Room.databaseBuilder(
+                    context.applicationContext, QuickFixRoomDatabase::class.java, "app_database")
+                .fallbackToDestructiveMigration() // Remove for production, add migrations instead
+                .build()
+                .also { INSTANCE = it }
+          }
     }
+  }
 }

--- a/app/src/main/java/com/arygm/quickfix/model/offline/large/QuickFixRoomDatabase.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/offline/large/QuickFixRoomDatabase.kt
@@ -1,0 +1,32 @@
+package com.arygm.quickfix.model.offline.large
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.arygm.quickfix.model.offline.large.messaging.ChatDao
+import com.arygm.quickfix.model.offline.large.messaging.ChatEntity
+
+@Database(entities = [ChatEntity::class], version = 1)
+@TypeConverters(Converters::class)
+abstract class QuickFixRoomDatabase : RoomDatabase() {
+    abstract fun chatDao(): ChatDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: QuickFixRoomDatabase? = null
+
+        fun getInstance(context: Context): QuickFixRoomDatabase {
+            return INSTANCE ?: synchronized(this) {
+                Room.databaseBuilder(
+                    context.applicationContext,
+                    QuickFixRoomDatabase::class.java,
+                    "app_database"
+                )
+                    .fallbackToDestructiveMigration() // Remove for production, add migrations instead
+                    .build().also { INSTANCE = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arygm/quickfix/model/offline/large/messaging/ChatDao.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/offline/large/messaging/ChatDao.kt
@@ -8,15 +8,12 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ChatDao {
-    @Query("SELECT * FROM chats WHERE chatId = :chatId")
-    suspend fun getChatById(chatId: String): ChatEntity?
+  @Query("SELECT * FROM chats WHERE chatId = :chatId")
+  suspend fun getChatById(chatId: String): ChatEntity?
 
-    @Query("SELECT * FROM chats")
-    fun getAllChats(): Flow<List<ChatEntity>>
+  @Query("SELECT * FROM chats") fun getAllChats(): Flow<List<ChatEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertChat(chat: ChatEntity)
+  @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun insertChat(chat: ChatEntity)
 
-    @Query("DELETE FROM chats WHERE chatId = :chatId")
-    suspend fun deleteChat(chatId: String)
+  @Query("DELETE FROM chats WHERE chatId = :chatId") suspend fun deleteChat(chatId: String)
 }

--- a/app/src/main/java/com/arygm/quickfix/model/offline/large/messaging/ChatDao.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/offline/large/messaging/ChatDao.kt
@@ -1,0 +1,22 @@
+package com.arygm.quickfix.model.offline.large.messaging
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ChatDao {
+    @Query("SELECT * FROM chats WHERE chatId = :chatId")
+    suspend fun getChatById(chatId: String): ChatEntity?
+
+    @Query("SELECT * FROM chats")
+    fun getAllChats(): Flow<List<ChatEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertChat(chat: ChatEntity)
+
+    @Query("DELETE FROM chats WHERE chatId = :chatId")
+    suspend fun deleteChat(chatId: String)
+}

--- a/app/src/main/java/com/arygm/quickfix/model/offline/large/messaging/ChatEntity.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/offline/large/messaging/ChatEntity.kt
@@ -12,12 +12,11 @@ data class ChatEntity(
     val useruid: String,
     val messages: String // Serialized List<Message>
 ) {
-    fun toChat(): Chat {
-        return Chat(
-            chatId = chatId,
-            workeruid = workeruid,
-            useruid = useruid,
-            messages = Converters().toMessagesList(messages)
-        )
-    }
+  fun toChat(): Chat {
+    return Chat(
+        chatId = chatId,
+        workeruid = workeruid,
+        useruid = useruid,
+        messages = Converters().toMessagesList(messages))
+  }
 }

--- a/app/src/main/java/com/arygm/quickfix/model/offline/large/messaging/ChatEntity.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/offline/large/messaging/ChatEntity.kt
@@ -1,0 +1,23 @@
+package com.arygm.quickfix.model.offline.large.messaging
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.arygm.quickfix.model.messaging.Chat
+import com.arygm.quickfix.model.offline.large.Converters
+
+@Entity(tableName = "chats")
+data class ChatEntity(
+    @PrimaryKey val chatId: String,
+    val workeruid: String,
+    val useruid: String,
+    val messages: String // Serialized List<Message>
+) {
+    fun toChat(): Chat {
+        return Chat(
+            chatId = chatId,
+            workeruid = workeruid,
+            useruid = useruid,
+            messages = Converters().toMessagesList(messages)
+        )
+    }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/noModeUI/authentication/WelcomeScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/noModeUI/authentication/WelcomeScreen.kt
@@ -119,7 +119,6 @@ fun WelcomeScreen(
     // Navigate to RegistrationScreen
   }
   // Animation sequence when the Register button is clicked
-  @Composable
   if (startAnimation) {
     LaunchedEffect(Unit) {
       fadeOut = true // Start fade-out animation

--- a/app/src/test/java/com/arygm/quickfix/model/messaging/ChatRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/messaging/ChatRepositoryFirestoreTest.kt
@@ -1,66 +1,54 @@
 package com.arygm.quickfix.model.messaging
 
-import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
-import com.google.android.gms.tasks.TaskCompletionSource
+import com.arygm.quickfix.model.offline.large.messaging.ChatDao
+import com.arygm.quickfix.model.offline.large.messaging.ChatEntity
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.FirebaseApp
-import com.google.firebase.Timestamp
-import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.DocumentSnapshot
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.Query
-import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.*
+import java.util.UUID
 import junit.framework.TestCase.fail
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.verify
+import org.mockito.kotlin.*
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 class ChatRepositoryFirestoreTest {
 
   @Mock private lateinit var mockFirestore: FirebaseFirestore
-
   @Mock private lateinit var mockChatsCollection: CollectionReference
-
   @Mock private lateinit var mockChatDocument: DocumentReference
-
-  @Mock private lateinit var mockMessagesCollection: CollectionReference
-
-  @Mock private lateinit var mockMessageDocument: DocumentReference
-
-  @Mock private lateinit var mockQuery: Query
-
+  @Mock private lateinit var mockDao: ChatDao
   @Mock private lateinit var mockQuerySnapshot: QuerySnapshot
 
-  @Mock private lateinit var mockDocumentSnapshot: DocumentSnapshot
+  @OptIn(ExperimentalCoroutinesApi::class) private val testDispatcher = UnconfinedTestDispatcher()
 
   private lateinit var chatRepositoryFirestore: ChatRepositoryFirestore
 
-  private val chat = Chat(chatId = "user1worker1", useruid = "user1", workeruid = "worker1")
+  private val chat =
+      Chat(
+          chatId = "user1worker1",
+          useruid = "user1",
+          workeruid = "worker1",
+          quickFixUid = "someQuickFixUid",
+          messages = emptyList(),
+          chatStatus = ChatStatus.WAITING_FOR_RESPONSE)
 
-  private val chat2 = Chat(chatId = "user2worker2", useruid = "user2", workeruid = "worker2")
-
-  private val message =
-      Message(
-          messageId = "message1", senderId = "user1", content = "Hello", timestamp = Timestamp.now()
-          // Add other fields as necessary
-          )
+  private val chatEntity =
+      ChatEntity(chatId = "user1worker1", useruid = "user1", workeruid = "worker1", messages = "[]")
 
   @Before
   fun setUp() {
@@ -70,12 +58,26 @@ class ChatRepositoryFirestoreTest {
       FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
     }
 
-    chatRepositoryFirestore = ChatRepositoryFirestore(mockFirestore)
+    chatRepositoryFirestore = ChatRepositoryFirestore(mockDao, mockFirestore, testDispatcher)
 
-    Mockito.`when`(mockFirestore.collection(any())).thenReturn(mockChatsCollection)
-    Mockito.`when`(mockChatsCollection.document(any())).thenReturn(mockChatDocument)
-    Mockito.`when`(mockChatDocument.collection(any())).thenReturn(mockMessagesCollection)
-    Mockito.`when`(mockMessagesCollection.document(any())).thenReturn(mockMessageDocument)
+    // Mock Firestore collection and document references
+    whenever(mockFirestore.collection(any())).thenReturn(mockChatsCollection)
+    whenever(mockChatsCollection.document(any())).thenReturn(mockChatDocument)
+
+    // Mock Task<QuerySnapshot> for chats.get()
+    @Suppress("UNCHECKED_CAST")
+    val mockTask: Task<QuerySnapshot> = Mockito.mock(Task::class.java) as Task<QuerySnapshot>
+    whenever(mockChatsCollection.get()).thenReturn(mockTask)
+
+    // Mock Task success with a QuerySnapshot
+    whenever(mockTask.addOnSuccessListener(any())).thenAnswer { invocation ->
+      val listener = invocation.arguments[0] as OnSuccessListener<QuerySnapshot>
+      listener.onSuccess(mockQuerySnapshot)
+      mockTask
+    }
+
+    // No forced failure scenario here
+    whenever(mockTask.addOnFailureListener(any())).thenReturn(mockTask)
   }
 
   @After
@@ -83,543 +85,276 @@ class ChatRepositoryFirestoreTest {
     // No specific teardown required
   }
 
-  // ----- Init Method Test -----
-
   @Test
-  fun init_callsOnSuccess() {
-    var callbackCalled = false
-    chatRepositoryFirestore.init(onSuccess = { callbackCalled = true })
-    assertTrue(callbackCalled)
-  }
-
-  // ----- Create Chat Tests -----
-
-  @Test
-  fun createChat_callsSetOnChatDocument() {
-    Mockito.`when`(mockChatDocument.set(any<Chat>())).thenReturn(Tasks.forResult(null))
-
-    chatRepositoryFirestore.createChat(
-        chat, onSuccess = {}, onFailure = { fail("Failure callback should not be called") })
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    verify(mockChatDocument).set(eq(chat))
+  fun test_init_callsOnSuccessImmediately() {
+    var successCalled = false
+    chatRepositoryFirestore.init(onSuccess = { successCalled = true })
+    assertTrue(successCalled)
   }
 
   @Test
-  fun createChat_onSuccess_callsOnSuccess() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    Mockito.`when`(mockChatDocument.set(any<Chat>())).thenReturn(taskCompletionSource.task)
+  fun test_getRandomUid_generatesUniqueId() {
+    val randomDocRef = Mockito.mock(DocumentReference::class.java)
+    val generatedId = UUID.randomUUID().toString()
+    whenever(mockChatsCollection.document()).thenReturn(randomDocRef)
+    whenever(randomDocRef.id).thenReturn(generatedId)
 
-    var callbackCalled = false
-
-    chatRepositoryFirestore.createChat(
-        chat = chat,
-        onSuccess = { callbackCalled = true },
-        onFailure = { fail("Failure callback should not be called") })
-
-    taskCompletionSource.setResult(null)
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
+    val uid = chatRepositoryFirestore.getRandomUid()
+    assertEquals(generatedId, uid)
   }
 
   @Test
-  fun createChat_onFailure_callsOnFailure() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    Mockito.`when`(mockChatDocument.set(any<Chat>())).thenReturn(taskCompletionSource.task)
+  fun test_getChats_returnsCachedData_whenAvailable() {
+    runBlocking {
+      // Mock ChatDao returning cached chats
+      whenever(mockDao.getAllChats()).thenReturn(flowOf(listOf(chatEntity)))
 
-    val exception = Exception("Test exception")
-    var callbackCalled = false
-    var returnedException: Exception? = null
+      var returnedChats: List<Chat>? = null
 
-    chatRepositoryFirestore.createChat(
-        chat = chat,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { e ->
-          callbackCalled = true
-          returnedException = e
-        })
+      chatRepositoryFirestore.getChats(
+          onSuccess = { chats -> returnedChats = chats },
+          onFailure = { fail("Failure callback should not be called") })
 
-    taskCompletionSource.setException(exception)
+      // Verify cached chats are returned
+      assertNotNull(returnedChats)
+      assertEquals(1, returnedChats?.size)
+      assertEquals(chat.chatId, returnedChats?.first()?.chatId)
 
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
-    assertEquals(exception, returnedException)
-  }
-
-  // ----- Delete Chat Tests -----
-
-  @Test
-  fun deleteChat_callsDeleteOnChatDocument() {
-    Mockito.`when`(mockChatDocument.delete()).thenReturn(Tasks.forResult(null))
-
-    chatRepositoryFirestore.deleteChat(
-        chat, onSuccess = {}, onFailure = { fail("Failure callback should not be called") })
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    verify(mockChatDocument).delete()
+      // Verify Firestore was NOT called
+      verify(mockChatsCollection, times(0)).get()
+    }
   }
 
   @Test
-  fun deleteChat_onSuccess_callsOnSuccess() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    Mockito.`when`(mockChatDocument.delete()).thenReturn(taskCompletionSource.task)
+  fun test_getChats_fallsBackToFirestore_whenCacheIsEmpty() {
+    runBlocking {
+      // Mock ChatDao returning empty cache
+      whenever(mockDao.getAllChats()).thenReturn(flowOf(emptyList()))
 
-    var callbackCalled = false
+      // Mock the DocumentSnapshot so that documentToChat(document) will succeed
+      val document1 = Mockito.mock(DocumentSnapshot::class.java)
+      whenever(document1.getString("chatId")).thenReturn("user1worker1")
+      whenever(document1.getString("workeruid")).thenReturn("worker1")
+      whenever(document1.getString("useruid")).thenReturn("user1")
+      whenever(document1.getString("quickFixUid")).thenReturn("someQuickFixUid")
+      whenever(document1.getString("chatStatus")).thenReturn("WAITING_FOR_RESPONSE")
+      whenever(document1.get("messages")).thenReturn(emptyList<Map<String, Any>>())
 
-    chatRepositoryFirestore.deleteChat(
-        chat = chat,
-        onSuccess = { callbackCalled = true },
-        onFailure = { fail("Failure callback should not be called") })
+      whenever(mockQuerySnapshot.documents).thenReturn(listOf(document1))
 
-    taskCompletionSource.setResult(null)
+      var returnedChats: List<Chat>? = null
 
-    shadowOf(Looper.getMainLooper()).idle()
+      chatRepositoryFirestore.getChats(
+          onSuccess = { chats -> returnedChats = chats },
+          onFailure = { fail("Failure callback should not be called") })
 
-    assertTrue(callbackCalled)
+      // Verify Firestore was called
+      verify(mockChatsCollection).get()
+
+      // Verify chats were cached in Room
+      verify(mockDao).insertChat(chat.toChatEntity())
+
+      // Verify returned chats
+      assertNotNull(returnedChats)
+      assertEquals(1, returnedChats?.size)
+      assertEquals(chat.chatId, returnedChats?.first()?.chatId)
+    }
   }
 
   @Test
-  fun deleteChat_onFailure_callsOnFailure() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    Mockito.`when`(mockChatDocument.delete()).thenReturn(taskCompletionSource.task)
+  fun test_createChat_cachesChatInRoom_beforeCallingFirestore() {
+    runBlocking {
+      // Mock Firestore success
+      whenever(mockChatDocument.set(any<Chat>())).thenReturn(Tasks.forResult(null))
 
-    val exception = Exception("Test exception")
-    var callbackCalled = false
-    var returnedException: Exception? = null
+      chatRepositoryFirestore.createChat(
+          chat = chat,
+          onSuccess = {},
+          onFailure = { fail("Failure callback should not be called") })
 
-    chatRepositoryFirestore.deleteChat(
-        chat = chat,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { e ->
-          callbackCalled = true
-          returnedException = e
-        })
+      // Verify chat was cached in Room
+      verify(mockDao).insertChat(chat.toChatEntity())
 
-    taskCompletionSource.setException(exception)
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
-    assertEquals(exception, returnedException)
-  }
-
-  // ----- Get Chats Tests -----
-
-  @Test
-  fun getChats_onSuccess_callsOnSuccessWithChats() {
-    val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
-    Mockito.`when`(mockChatsCollection.get()).thenReturn(taskCompletionSource.task)
-
-    val document1 = Mockito.mock(DocumentSnapshot::class.java)
-    val document2 = Mockito.mock(DocumentSnapshot::class.java)
-
-    Mockito.`when`(document1.toObject(Chat::class.java)).thenReturn(chat)
-    Mockito.`when`(document2.toObject(Chat::class.java)).thenReturn(chat2)
-    Mockito.`when`(mockQuerySnapshot.documents).thenReturn(listOf(document1, document2))
-
-    var callbackCalled = false
-    var returnedChats: List<Chat>? = null
-
-    chatRepositoryFirestore.getChats(
-        onSuccess = { chats ->
-          callbackCalled = true
-          returnedChats = chats
-        },
-        onFailure = { fail("Failure callback should not be called") })
-
-    taskCompletionSource.setResult(mockQuerySnapshot)
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
-    assertNotNull(returnedChats)
+      // Verify Firestore was called
+      verify(mockChatDocument).set(eq(chat))
+    }
   }
 
   @Test
-  fun getChats_onFailure_callsOnFailure() {
-    val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
-    Mockito.`when`(mockChatsCollection.get()).thenReturn(taskCompletionSource.task)
+  fun test_deleteChat_removesFromRoomAndFirestore() {
+    runBlocking {
+      // Mock DAO and Firestore operations
+      whenever(mockDao.deleteChat(chat.chatId)).thenReturn(Unit)
+      val deleteTask: Task<Void> = Tasks.forResult(null)
+      whenever(mockChatDocument.delete()).thenReturn(deleteTask)
 
-    val exception = Exception("Test exception")
+      var successCalled = false
+      chatRepositoryFirestore.deleteChat(
+          chat = chat,
+          onSuccess = { successCalled = true },
+          onFailure = { fail("Should not fail") })
 
-    var callbackCalled = false
-    var returnedException: Exception? = null
-
-    chatRepositoryFirestore.getChats(
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { e ->
-          callbackCalled = true
-          returnedException = e
-        })
-
-    taskCompletionSource.setException(exception)
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
-    assertEquals(exception, returnedException)
-  }
-
-  // ----- Chat Exists Tests -----
-
-  @Test
-  fun chatExists_whenChatExists_callsOnSuccessWithTrueAndChat() {
-    val userId = "user1"
-    val workerId = "worker1"
-
-    Mockito.`when`(mockChatsCollection.whereEqualTo(eq("chatId"), eq(userId + workerId)))
-        .thenReturn(mockQuery)
-    Mockito.`when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
-    Mockito.`when`(mockQuerySnapshot.size()).thenReturn(1)
-    Mockito.`when`(mockQuerySnapshot.toObjects(Chat::class.java)).thenReturn(listOf(chat))
-
-    var callbackCalled = false
-
-    chatRepositoryFirestore.chatExists(
-        userId = userId,
-        workerId = workerId,
-        onSuccess = { (exists, foundChat) ->
-          callbackCalled = true
-          assertTrue(exists)
-          assertEquals(chat, foundChat)
-        },
-        onFailure = { fail("Failure callback should not be called") })
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
+      // Verify local deletion
+      verify(mockDao).deleteChat(chat.chatId)
+      // Verify Firestore deletion
+      verify(mockChatDocument).delete()
+      assertTrue(successCalled)
+    }
   }
 
   @Test
-  fun chatExists_whenChatDoesNotExist_callsOnSuccessWithFalseAndNull() {
-    val userId = "user1"
-    val workerId = "worker1"
+  fun test_chatExists_returnsTrueIfLocalChatExists() {
+    runBlocking {
+      // Mock DAO to return the chat locally
+      whenever(mockDao.getChatById(chat.chatId)).thenReturn(chatEntity)
 
-    Mockito.`when`(mockChatsCollection.whereEqualTo(eq("chatId"), eq(userId + workerId)))
-        .thenReturn(mockQuery)
-    Mockito.`when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
-    Mockito.`when`(mockQuerySnapshot.size()).thenReturn(0)
-    Mockito.`when`(mockQuerySnapshot.toObjects(Chat::class.java)).thenReturn(emptyList())
+      var result: Pair<Boolean, Chat?>? = null
+      chatRepositoryFirestore.chatExists(
+          userId = "user1",
+          workerId = "worker1",
+          onSuccess = { result = it },
+          onFailure = { fail("Should not fail") })
 
-    var callbackCalled = false
+      assertNotNull(result)
+      assertTrue(result!!.first)
+      assertEquals(chat.chatId, result!!.second?.chatId)
 
-    chatRepositoryFirestore.chatExists(
-        userId = userId,
-        workerId = workerId,
-        onSuccess = { (exists, foundChat) ->
-          callbackCalled = true
-          assertFalse(exists)
-          assertNull(foundChat)
-        },
-        onFailure = { fail("Failure callback should not be called") })
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
+      // Verify Firestore not called since local chat found
+      verify(mockChatsCollection, times(0)).whereEqualTo("chatId", chat.chatId)
+    }
   }
 
   @Test
-  fun chatExists_onFailure_callsOnFailure() {
-    val userId = "user1"
-    val workerId = "worker1"
-    val exception = Exception("Test exception")
+  fun test_chatExists_fallsBackToFirestoreIfLocalNotFound() {
+    runBlocking {
+      // No local chat
+      whenever(mockDao.getChatById(chat.chatId)).thenReturn(null)
 
-    Mockito.`when`(mockChatsCollection.whereEqualTo(eq("chatId"), eq(userId + workerId)))
-        .thenReturn(mockQuery)
-    Mockito.`when`(mockQuery.get()).thenReturn(Tasks.forException(exception))
+      // Mock Firestore response
+      val mockQuery = Mockito.mock(Query::class.java)
+      whenever(mockChatsCollection.whereEqualTo("chatId", chat.chatId)).thenReturn(mockQuery)
 
-    var callbackCalled = false
-    var returnedException: Exception? = null
+      @Suppress("UNCHECKED_CAST")
+      val mockTask: Task<QuerySnapshot> = Mockito.mock(Task::class.java) as Task<QuerySnapshot>
+      whenever(mockQuery.get()).thenReturn(mockTask)
 
-    chatRepositoryFirestore.chatExists(
-        userId = userId,
-        workerId = workerId,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { e ->
-          callbackCalled = true
-          returnedException = e
-        })
+      whenever(mockTask.addOnSuccessListener(any())).thenAnswer { invocation ->
+        val listener = invocation.arguments[0] as OnSuccessListener<QuerySnapshot>
+        // Simulate Firestore returning the chat
+        whenever(mockQuerySnapshot.toObjects(Chat::class.java)).thenReturn(listOf(chat))
+        listener.onSuccess(mockQuerySnapshot)
+        mockTask
+      }
 
-    shadowOf(Looper.getMainLooper()).idle()
+      whenever(mockTask.addOnFailureListener(any())).thenReturn(mockTask)
 
-    assertTrue(callbackCalled)
-    assertEquals(exception, returnedException)
-  }
+      var result: Pair<Boolean, Chat?>? = null
+      chatRepositoryFirestore.chatExists(
+          userId = "user1",
+          workerId = "worker1",
+          onSuccess = { result = it },
+          onFailure = { fail("Should not fail") })
 
-  // ----- Send Message Tests -----
-
-  @Test
-  fun sendMessage_callsUpdateOnChatDocument() {
-    Mockito.`when`(mockChatDocument.update(eq("messages"), any())).thenReturn(Tasks.forResult(null))
-
-    chatRepositoryFirestore.sendMessage(
-        chat = chat,
-        message = message,
-        onSuccess = {},
-        onFailure = { fail("Failure callback should not be called") })
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    verify(mockChatDocument).update(eq("messages"), any())
+      assertNotNull(result)
+      assertTrue(result!!.first)
+      assertEquals(chat.chatId, result!!.second?.chatId)
+    }
   }
 
   @Test
-  fun sendMessage_onSuccess_callsOnSuccess() {
-    Mockito.`when`(mockChatDocument.update(eq("messages"), any())).thenReturn(Tasks.forResult(null))
+  fun test_sendMessage_updatesRoomAndFirestore() {
+    runBlocking {
+      // Mock DAO insert success
+      whenever(mockDao.insertChat(any())).thenReturn(Unit)
 
-    var callbackCalled = false
+      // Mock Firestore update success
+      val updateTask: Task<Void> = Tasks.forResult(null)
+      whenever(mockChatDocument.update(eq("messages"), any())).thenReturn(updateTask)
 
-    chatRepositoryFirestore.sendMessage(
-        chat = chat,
-        message = message,
-        onSuccess = { callbackCalled = true },
-        onFailure = { fail("Failure callback should not be called") })
+      val message =
+          Message(
+              messageId = "msg1",
+              senderId = "user1",
+              content = "Hello",
+              timestamp = com.google.firebase.Timestamp.now())
 
-    shadowOf(Looper.getMainLooper()).idle()
+      var successCalled = false
+      chatRepositoryFirestore.sendMessage(
+          chat = chat,
+          message = message,
+          onSuccess = { successCalled = true },
+          onFailure = { fail("Should not fail") })
 
-    assertTrue(callbackCalled)
+      // Verify DAO insert with the updated chat
+      argumentCaptor<ChatEntity>().apply {
+        verify(mockDao).insertChat(capture())
+        assertTrue(firstValue.messages.contains("\"messageId\":\"msg1\""))
+      }
+
+      // Verify Firestore update
+      verify(mockChatDocument).update(eq("messages"), any())
+    }
   }
 
   @Test
-  fun sendMessage_onFailure_callsOnFailure() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    Mockito.`when`(mockChatDocument.update(eq("messages"), any()))
-        .thenReturn(taskCompletionSource.task)
+  fun test_deleteMessage_updatesRoomAndFirestore() {
+    runBlocking {
+      // Mock a chat with a message
+      val message =
+          Message(
+              messageId = "msgToDelete",
+              senderId = "user1",
+              content = "This will be deleted",
+              timestamp = com.google.firebase.Timestamp.now())
+      val chatWithMessage = chat.copy(messages = listOf(message))
+      whenever(mockDao.insertChat(any())).thenReturn(Unit)
 
-    val exception = Exception("Test exception")
-    var callbackCalled = false
-    var returnedException: Exception? = null
+      // Mock Firestore deletion success
+      val messageDoc = Mockito.mock(DocumentReference::class.java)
+      val messagesCollection = Mockito.mock(CollectionReference::class.java)
+      whenever(mockChatDocument.collection("messages")).thenReturn(messagesCollection)
+      whenever(messagesCollection.document(message.messageId)).thenReturn(messageDoc)
+      whenever(messageDoc.delete()).thenReturn(Tasks.forResult(null))
 
-    chatRepositoryFirestore.sendMessage(
-        chat = chat,
-        message = message,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { e ->
-          callbackCalled = true
-          returnedException = e
-        })
+      var successCalled = false
+      chatRepositoryFirestore.deleteMessage(
+          chat = chatWithMessage,
+          message = message,
+          onSuccess = { successCalled = true },
+          onFailure = { fail("Should not fail") })
 
-    taskCompletionSource.setException(exception)
+      // Verify DAO updated chat no longer has the message
+      argumentCaptor<ChatEntity>().apply {
+        verify(mockDao).insertChat(capture())
+        assertFalse(firstValue.messages.contains("\"msgToDelete\""))
+      }
 
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
-    assertEquals(exception, returnedException)
-  }
-
-  // ----- Delete Message Tests -----
-
-  @Test
-  fun deleteMessage_callsDeleteOnMessageDocument() {
-    Mockito.`when`(mockMessageDocument.delete()).thenReturn(Tasks.forResult(null))
-
-    chatRepositoryFirestore.deleteMessage(
-        chat = chat,
-        message = message,
-        onSuccess = {},
-        onFailure = { fail("Failure callback should not be called") })
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    verify(mockMessageDocument).delete()
+      // Verify Firestore message deletion
+      verify(messageDoc).delete()
+      assertTrue(successCalled)
+    }
   }
 
   @Test
-  fun deleteMessage_onSuccess_callsOnSuccess() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    Mockito.`when`(mockMessageDocument.delete()).thenReturn(taskCompletionSource.task)
+  fun test_updateChat_updatesRoomAndFirestore() {
+    runBlocking {
+      // Mock DAO insert success
+      whenever(mockDao.insertChat(any())).thenReturn(Unit)
+      // Mock Firestore set success
+      whenever(mockChatDocument.set(any<Chat>())).thenReturn(Tasks.forResult(null))
 
-    var callbackCalled = false
+      var successCalled = false
+      chatRepositoryFirestore.updateChat(
+          chat = chat,
+          onSuccess = { successCalled = true },
+          onFailure = { fail("Should not fail") })
 
-    chatRepositoryFirestore.deleteMessage(
-        chat = chat,
-        message = message,
-        onSuccess = { callbackCalled = true },
-        onFailure = { fail("Failure callback should not be called") })
+      // Verify DAO was updated
+      verify(mockDao).insertChat(chat.toChatEntity())
 
-    taskCompletionSource.setResult(null)
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
-  }
-
-  @Test
-  fun deleteMessage_onFailure_callsOnFailure() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    Mockito.`when`(mockMessageDocument.delete()).thenReturn(taskCompletionSource.task)
-
-    val exception = Exception("Test exception")
-    var callbackCalled = false
-    var returnedException: Exception? = null
-
-    chatRepositoryFirestore.deleteMessage(
-        chat = chat,
-        message = message,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { e ->
-          callbackCalled = true
-          returnedException = e
-        })
-
-    taskCompletionSource.setException(exception)
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    assertTrue(callbackCalled)
-    assertEquals(exception, returnedException)
-  }
-
-  @Test
-  fun updateChat_onSuccess_callsOnSuccess() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    Mockito.`when`(mockChatDocument.set(any<Chat>())).thenReturn(taskCompletionSource.task)
-
-    var callbackCalled = false
-
-    // Appel de la méthode à tester
-    chatRepositoryFirestore.updateChat(
-        chat = chat,
-        onSuccess = { callbackCalled = true },
-        onFailure = { fail("Failure callback should not be called") })
-
-    // Simule un succès de l'opération Firestore
-    taskCompletionSource.setResult(null)
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    // Vérifie que le callback de succès a été appelé
-    assertTrue(callbackCalled)
-  }
-
-  @Test
-  fun updateChat_onFailure_callsOnFailure() {
-    val taskCompletionSource = TaskCompletionSource<Void>()
-    Mockito.`when`(mockChatDocument.set(any<Chat>())).thenReturn(taskCompletionSource.task)
-
-    val exception = Exception("Test exception")
-    var callbackCalled = false
-    var returnedException: Exception? = null
-
-    // Appel de la méthode à tester
-    chatRepositoryFirestore.updateChat(
-        chat = chat,
-        onSuccess = { fail("Success callback should not be called") },
-        onFailure = { e ->
-          callbackCalled = true
-          returnedException = e
-        })
-
-    // Simule un échec de l'opération Firestore
-    taskCompletionSource.setException(exception)
-
-    shadowOf(Looper.getMainLooper()).idle()
-
-    // Vérifie que le callback d'échec a été appelé avec la bonne exception
-    assertTrue(callbackCalled)
-    assertEquals(exception, returnedException)
-  }
-
-  @Test
-  fun `documentToChat transforms valid DocumentSnapshot into Chat`() {
-    // Mock a valid Firestore DocumentSnapshot
-    Mockito.`when`(mockDocumentSnapshot.getString("chatId")).thenReturn("chat123")
-    Mockito.`when`(mockDocumentSnapshot.getString("workeruid")).thenReturn("worker123")
-    Mockito.`when`(mockDocumentSnapshot.getString("useruid")).thenReturn("user123")
-    Mockito.`when`(mockDocumentSnapshot.getString("quickFixUid")).thenReturn("quickfix123")
-    Mockito.`when`(mockDocumentSnapshot.getString("chatStatus"))
-        .thenReturn(ChatStatus.ACCEPTED.name)
-
-    val messages =
-        listOf(
-            mapOf(
-                "messageId" to "msg1",
-                "senderId" to "user123",
-                "content" to "Hello",
-                "timestamp" to com.google.firebase.Timestamp.now()),
-            mapOf(
-                "messageId" to "msg2",
-                "senderId" to "worker123",
-                "content" to "Hi there!",
-                "timestamp" to com.google.firebase.Timestamp.now()))
-    Mockito.`when`(mockDocumentSnapshot.get("messages")).thenReturn(messages)
-
-    // Simulate Firestore QuerySnapshot containing this document
-    Mockito.`when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
-
-    val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
-    Mockito.`when`(mockChatsCollection.get()).thenReturn(taskCompletionSource.task)
-
-    var callbackCalled = false
-    var returnedChats: List<Chat>? = null
-
-    // Call the public method that uses documentToChat
-    chatRepositoryFirestore.getChats(
-        onSuccess = { chats ->
-          callbackCalled = true
-          returnedChats = chats
-        },
-        onFailure = { fail("Failure callback should not be called") })
-
-    // Simulate successful Firestore query
-    taskCompletionSource.setResult(mockQuerySnapshot)
-    shadowOf(Looper.getMainLooper()).idle()
-
-    // Assertions
-    assertTrue(callbackCalled)
-    assertNotNull(returnedChats)
-    assertEquals(1, returnedChats?.size)
-
-    val chat = returnedChats?.first()
-    assertEquals("chat123", chat?.chatId)
-    assertEquals("worker123", chat?.workeruid)
-    assertEquals("user123", chat?.useruid)
-    assertEquals("quickfix123", chat?.quickFixUid)
-    assertEquals(ChatStatus.ACCEPTED, chat?.chatStatus)
-    assertEquals(2, chat?.messages?.size)
-
-    val firstMessage = chat?.messages?.get(0)
-    assertEquals("msg1", firstMessage?.messageId)
-    assertEquals("Hello", firstMessage?.content)
-    assertEquals("user123", firstMessage?.senderId)
-  }
-
-  @Test
-  fun `documentToChat handles missing fields gracefully`() {
-    // Mock a DocumentSnapshot with missing fields
-    Mockito.`when`(mockDocumentSnapshot.getString("chatId")).thenReturn(null)
-    Mockito.`when`(mockDocumentSnapshot.getString("workeruid")).thenReturn("worker123")
-    Mockito.`when`(mockDocumentSnapshot.getString("useruid")).thenReturn("user123")
-    Mockito.`when`(mockDocumentSnapshot.getString("chatStatus"))
-        .thenReturn(ChatStatus.ACCEPTED.name)
-
-    val taskCompletionSource = TaskCompletionSource<QuerySnapshot>()
-    Mockito.`when`(mockChatsCollection.get()).thenReturn(taskCompletionSource.task)
-
-    var callbackCalled = false
-    var returnedChats: List<Chat>? = null
-
-    // Call the public method that uses documentToChat
-    chatRepositoryFirestore.getChats(
-        onSuccess = { chats ->
-          callbackCalled = true
-          returnedChats = chats
-        },
-        onFailure = { fail("Failure callback should not be called") })
-
-    // Simulate successful Firestore query with an invalid document
-    Mockito.`when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
-    taskCompletionSource.setResult(mockQuerySnapshot)
-    shadowOf(Looper.getMainLooper()).idle()
-
-    // Assertions
-    assertTrue(callbackCalled)
-    assertNotNull(returnedChats)
-    assertEquals(0, returnedChats?.size) // Invalid documents should be ignored
+      // Verify Firestore set
+      verify(mockChatDocument).set(eq(chat))
+      assertTrue(successCalled)
+    }
   }
 }

--- a/app/src/test/java/com/arygm/quickfix/model/messaging/ChatViewModelTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/messaging/ChatViewModelTest.kt
@@ -103,7 +103,7 @@ class ChatViewModelTest {
   @Test
   fun addChat_whenSuccess_updatesChats() = runTest {
     var onSuccessCalled = false
-
+    chatViewModel = ChatViewModel(mockRepository, testDispatcher)
     doAnswer { invocation ->
           val onSuccess = invocation.getArgument<() -> Unit>(1)
           onSuccess()
@@ -184,7 +184,6 @@ class ChatViewModelTest {
 
     assertEquals(emptyList<Chat>(), chatViewModel.chats.value)
     verify(mockRepository).deleteChat(eq(chat), any(), any())
-    verify(mockRepository).getChats(any(), any())
   }
 
   @Test
@@ -292,6 +291,7 @@ class ChatViewModelTest {
 
   @Test
   fun sendMessage_whenSuccess_updatesChats() = runTest {
+    chatViewModel = ChatViewModel(mockRepository, testDispatcher)
     doAnswer { invocation ->
           val onSuccess = invocation.getArgument<() -> Unit>(2)
           onSuccess()
@@ -341,6 +341,7 @@ class ChatViewModelTest {
 
   @Test
   fun deleteMessage_whenSuccess_updatesChats() = runTest {
+    chatViewModel = ChatViewModel(mockRepository, testDispatcher)
     doAnswer { invocation ->
           val onSuccess = invocation.getArgument<() -> Unit>(2)
           onSuccess()
@@ -388,6 +389,7 @@ class ChatViewModelTest {
 
   @Test
   fun updateChat_whenSuccess_updatesChats() = runTest {
+    chatViewModel = ChatViewModel(mockRepository, testDispatcher)
     doAnswer { invocation ->
           val onSuccess = invocation.getArgument<() -> Unit>(1)
           onSuccess()

--- a/app/src/test/java/com/arygm/quickfix/model/offline/large/ConvertersTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/offline/large/ConvertersTest.kt
@@ -1,0 +1,79 @@
+package com.arygm.quickfix.model.offline.large
+
+import com.arygm.quickfix.model.messaging.Message
+import com.google.firebase.Timestamp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ConvertersTest {
+
+  private lateinit var converters: Converters
+
+  @Before
+  fun setUp() {
+    converters = Converters()
+  }
+
+  @Test
+  fun fromMessagesList_serializesCorrectly() {
+    val timestamp = Timestamp.now()
+    val messages =
+        listOf(
+            Message(messageId = "1", senderId = "user1", content = "Hello!", timestamp = timestamp),
+            Message(
+                messageId = "2",
+                senderId = "worker1",
+                content = "Hi there!",
+                timestamp = timestamp))
+
+    val json = converters.fromMessagesList(messages)
+    // Just check that it's not empty and contains known fields
+    assertTrue(json.isNotEmpty())
+    assertTrue(json.contains("user1"))
+    assertTrue(json.contains("worker1"))
+    assertTrue(json.contains("Hello!"))
+    assertTrue(json.contains("Hi there!"))
+  }
+
+  @Test
+  fun toMessagesList_deserializesCorrectly() {
+    val timestamp = Timestamp.now()
+    val messages =
+        listOf(
+            Message(messageId = "1", senderId = "user1", content = "Hello!", timestamp = timestamp),
+            Message(
+                messageId = "2",
+                senderId = "worker1",
+                content = "Hi there!",
+                timestamp = timestamp))
+
+    val json = converters.fromMessagesList(messages)
+    val deserialized = converters.toMessagesList(json)
+
+    assertEquals(messages.size, deserialized.size)
+    // Verify fields of the first message
+    assertEquals("1", deserialized[0].messageId)
+    assertEquals("user1", deserialized[0].senderId)
+    assertEquals("Hello!", deserialized[0].content)
+    // Timestamp comparison: we can check that the type matches or that the difference in time is
+    // minimal
+    // but for simplicity, we'll just assume if it deserialized without error it's correct.
+
+    // Verify fields of the second message
+    assertEquals("2", deserialized[1].messageId)
+    assertEquals("worker1", deserialized[1].senderId)
+    assertEquals("Hi there!", deserialized[1].content)
+  }
+
+  @Test
+  fun emptyList_serializesAndDeserializesCorrectly() {
+    val messages = emptyList<Message>()
+    val json = converters.fromMessagesList(messages)
+    assertTrue(json.isNotEmpty()) // Should be "[]"
+
+    val deserialized = converters.toMessagesList(json)
+    assertTrue(deserialized.isEmpty())
+  }
+}

--- a/app/src/test/java/com/arygm/quickfix/model/offline/large/QuickFixRoomDatabaseTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/offline/large/QuickFixRoomDatabaseTest.kt
@@ -47,4 +47,121 @@ class QuickFixRoomDatabaseTest {
     assertEquals("user1", retrieved.useruid)
     assertEquals("[]", retrieved.messages)
   }
+
+  @Test
+  fun getAllChats_emptyDatabase_returnsEmptyList() = runBlocking {
+    val allChats = chatDao.getAllChats().first()
+    assertTrue(allChats.isEmpty())
+  }
+
+  @Test
+  fun insertMultipleChats_andRetrieveAll() = runBlocking {
+    val chat1 =
+        ChatEntity(chatId = "chat1", workeruid = "workerA", useruid = "userA", messages = "[]")
+    val chat2 =
+        ChatEntity(chatId = "chat2", workeruid = "workerB", useruid = "userB", messages = "[]")
+    val chat3 =
+        ChatEntity(chatId = "chat3", workeruid = "workerC", useruid = "userC", messages = "[]")
+
+    chatDao.insertChat(chat1)
+    chatDao.insertChat(chat2)
+    chatDao.insertChat(chat3)
+
+    val allChats = chatDao.getAllChats().first()
+    assertEquals(3, allChats.size)
+    assertTrue(allChats.any { it.chatId == "chat1" })
+    assertTrue(allChats.any { it.chatId == "chat2" })
+    assertTrue(allChats.any { it.chatId == "chat3" })
+  }
+
+  @Test
+  fun getChatById_existingChat() = runBlocking {
+    val chat =
+        ChatEntity(
+            chatId = "uniqueChat",
+            workeruid = "workerX",
+            useruid = "userX",
+            messages = "[{\"text\":\"Hello\"}]")
+    chatDao.insertChat(chat)
+
+    val retrievedChat = chatDao.getChatById("uniqueChat")
+    assertNotNull(retrievedChat)
+    assertEquals("uniqueChat", retrievedChat?.chatId)
+    assertEquals("workerX", retrievedChat?.workeruid)
+    assertEquals("userX", retrievedChat?.useruid)
+    assertEquals("[{\"text\":\"Hello\"}]", retrievedChat?.messages)
+  }
+
+  @Test
+  fun getChatById_nonExistingChat_returnsNull() = runBlocking {
+    val retrievedChat = chatDao.getChatById("nonExistentChatId")
+    assertNull(retrievedChat)
+  }
+
+  @Test
+  fun insertChat_replaceExistingChat() = runBlocking {
+    val originalChat =
+        ChatEntity(
+            chatId = "replaceChat",
+            workeruid = "workerOriginal",
+            useruid = "userOriginal",
+            messages = "[{\"msg\":\"orig\"}]")
+    chatDao.insertChat(originalChat)
+
+    // Insert another chat with the same chatId but different data
+    val updatedChat =
+        ChatEntity(
+            chatId = "replaceChat",
+            workeruid = "workerUpdated",
+            useruid = "userUpdated",
+            messages = "[{\"msg\":\"updated\"}]")
+    chatDao.insertChat(updatedChat)
+
+    // Verify that the chat is replaced
+    val retrievedChat = chatDao.getChatById("replaceChat")
+    assertNotNull(retrievedChat)
+    assertEquals("workerUpdated", retrievedChat?.workeruid)
+    assertEquals("userUpdated", retrievedChat?.useruid)
+    assertEquals("[{\"msg\":\"updated\"}]", retrievedChat?.messages)
+  }
+
+  @Test
+  fun deleteChat_existingChat_removesIt() = runBlocking {
+    val chatToDelete =
+        ChatEntity(
+            chatId = "deleteMe",
+            workeruid = "delWorker",
+            useruid = "delUser",
+            messages = "[\"del\"]")
+    chatDao.insertChat(chatToDelete)
+
+    // Confirm it's there
+    val beforeDelete = chatDao.getChatById("deleteMe")
+    assertNotNull(beforeDelete)
+
+    // Delete and verify it's gone
+    chatDao.deleteChat("deleteMe")
+    val afterDelete = chatDao.getChatById("deleteMe")
+    assertNull(afterDelete)
+  }
+
+  @Test
+  fun deleteChat_doesNotAffectOthers() = runBlocking {
+    val chat1 = ChatEntity(chatId = "chatA", workeruid = "A", useruid = "A", messages = "[]")
+    val chat2 = ChatEntity(chatId = "chatB", workeruid = "B", useruid = "B", messages = "[]")
+    val chat3 = ChatEntity(chatId = "chatC", workeruid = "C", useruid = "C", messages = "[]")
+
+    chatDao.insertChat(chat1)
+    chatDao.insertChat(chat2)
+    chatDao.insertChat(chat3)
+
+    // Delete chat2
+    chatDao.deleteChat("chatB")
+
+    val allChats = chatDao.getAllChats().first()
+    assertEquals(2, allChats.size)
+    assertNull(chatDao.getChatById("chatB"))
+    assertNotNull(chatDao.getChatById("chatA"))
+    assertNotNull(chatDao.getChatById("chatC"))
+  }
 }

--- a/app/src/test/java/com/arygm/quickfix/model/offline/large/QuickFixRoomDatabaseTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/offline/large/QuickFixRoomDatabaseTest.kt
@@ -1,0 +1,50 @@
+package com.arygm.quickfix.model.offline.large
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.arygm.quickfix.model.offline.large.messaging.ChatDao
+import com.arygm.quickfix.model.offline.large.messaging.ChatEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class QuickFixRoomDatabaseTest {
+
+  private lateinit var database: QuickFixRoomDatabase
+  private lateinit var chatDao: ChatDao
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    database = Room.inMemoryDatabaseBuilder(context, QuickFixRoomDatabase::class.java).build()
+    chatDao = database.chatDao()
+  }
+
+  @After
+  fun tearDown() {
+    database.close()
+  }
+
+  @Test
+  fun insertAndRetrieveChatEntity() = runBlocking {
+    val chatEntity =
+        ChatEntity(chatId = "testChatId", workeruid = "worker1", useruid = "user1", messages = "[]")
+
+    chatDao.insertChat(chatEntity)
+
+    val allChats = chatDao.getAllChats().first()
+    assertEquals(1, allChats.size)
+    val retrieved = allChats[0]
+    assertEquals("testChatId", retrieved.chatId)
+    assertEquals("worker1", retrieved.workeruid)
+    assertEquals("user1", retrieved.useruid)
+    assertEquals("[]", retrieved.messages)
+  }
+}

--- a/app/src/test/java/com/arygm/quickfix/model/offline/large/messaging/ChatDaoTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/offline/large/messaging/ChatDaoTest.kt
@@ -1,0 +1,89 @@
+package com.arygm.quickfix.model.offline.large.messaging
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arygm.quickfix.model.offline.large.QuickFixRoomDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatDaoTest {
+
+  private lateinit var database: QuickFixRoomDatabase
+  private lateinit var chatDao: ChatDao
+
+  @Before
+  fun setup() {
+    // Create an in-memory database for testing
+    database =
+        Room.inMemoryDatabaseBuilder(
+                ApplicationProvider.getApplicationContext(), QuickFixRoomDatabase::class.java)
+            .allowMainThreadQueries()
+            .build() // Use main thread for simplicity in tests
+
+    chatDao = database.chatDao()
+  }
+
+  @After
+  fun teardown() {
+    database.close()
+  }
+
+  @Test
+  fun insertAndGetChatById() = runBlocking {
+    val chat =
+        ChatEntity(chatId = "chat1", workeruid = "worker1", useruid = "user1", messages = "[]")
+
+    // Insert a chat
+    chatDao.insertChat(chat)
+
+    // Retrieve the chat by ID
+    val retrievedChat = chatDao.getChatById("chat1")
+
+    // Assert that the retrieved chat matches the inserted chat
+    assertEquals(chat, retrievedChat)
+  }
+
+  @Test
+  fun getAllChats() = runBlocking {
+    val chat1 =
+        ChatEntity(chatId = "chat1", workeruid = "worker1", useruid = "user1", messages = "[]")
+    val chat2 =
+        ChatEntity(chatId = "chat2", workeruid = "worker2", useruid = "user2", messages = "[]")
+
+    // Insert chats
+    chatDao.insertChat(chat1)
+    chatDao.insertChat(chat2)
+
+    // Retrieve all chats
+    val allChats = chatDao.getAllChats().first()
+
+    // Assert the size and contents
+    assertEquals(2, allChats.size)
+    assertEquals(listOf(chat1, chat2), allChats)
+  }
+
+  @Test
+  fun deleteChat() = runBlocking {
+    val chat =
+        ChatEntity(chatId = "chat1", workeruid = "worker1", useruid = "user1", messages = "[]")
+
+    // Insert a chat
+    chatDao.insertChat(chat)
+
+    // Delete the chat
+    chatDao.deleteChat("chat1")
+
+    // Attempt to retrieve the deleted chat
+    val retrievedChat = chatDao.getChatById("chat1")
+
+    // Assert that the chat no longer exists
+    assertEquals(null, retrievedChat)
+  }
+}

--- a/app/src/test/java/com/arygm/quickfix/model/offline/large/messaging/ChatEntityTest.kt
+++ b/app/src/test/java/com/arygm/quickfix/model/offline/large/messaging/ChatEntityTest.kt
@@ -1,0 +1,78 @@
+package com.arygm.quickfix.model.offline.large.messaging
+
+import com.arygm.quickfix.model.messaging.Message
+import com.arygm.quickfix.model.offline.large.Converters
+import com.google.firebase.Timestamp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ChatEntityTest {
+
+  private lateinit var converters: Converters
+
+  @Before
+  fun setUp() {
+    converters = Converters()
+  }
+
+  @Test
+  fun toChat_returnsCorrectChatObject() {
+    // Given a list of messages
+    val timestamp = Timestamp.now()
+    val messagesList =
+        listOf(
+            Message(
+                messageId = "msg1", senderId = "user1", content = "Hello", timestamp = timestamp),
+            Message(
+                messageId = "msg2",
+                senderId = "worker1",
+                content = "Hi there!",
+                timestamp = timestamp))
+
+    // Convert the messages to a JSON string using the Converters
+    val messagesJson = converters.fromMessagesList(messagesList)
+
+    // Create a ChatEntity
+    val chatEntity =
+        ChatEntity(
+            chatId = "chat123", workeruid = "worker1", useruid = "user1", messages = messagesJson)
+
+    // When we call toChat()
+    val chat = chatEntity.toChat()
+
+    // Then the fields should match
+    assertEquals("chat123", chat.chatId)
+    assertEquals("worker1", chat.workeruid)
+    assertEquals("user1", chat.useruid)
+
+    // And messages should be correctly deserialized
+    assertEquals(messagesList.size, chat.messages.size)
+    assertTrue(chat.messages.any { it.messageId == "msg1" && it.content == "Hello" })
+    assertTrue(chat.messages.any { it.messageId == "msg2" && it.content == "Hi there!" })
+  }
+
+  @Test
+  fun toChat_withEmptyMessages_returnsChatWithEmptyList() {
+    // Given an empty messages JSON
+    val emptyMessagesJson = converters.fromMessagesList(emptyList())
+
+    // Create a ChatEntity
+    val chatEntity =
+        ChatEntity(
+            chatId = "chatEmpty",
+            workeruid = "workerEmpty",
+            useruid = "userEmpty",
+            messages = emptyMessagesJson)
+
+    // When we call toChat()
+    val chat = chatEntity.toChat()
+
+    // Then the fields should match and messages should be empty
+    assertEquals("chatEmpty", chat.chatId)
+    assertEquals("workerEmpty", chat.workeruid)
+    assertEquals("userEmpty", chat.useruid)
+    assertTrue(chat.messages.isEmpty())
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,6 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.ktfmt) apply false
     alias(libs.plugins.gms) apply false
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ calendar = "1.3.0"
 composeRatingbar = "1.3.12"
 databindingRuntime = "8.7.0"
 datastorePreferencesCore = "1.1.1"
-kotlin = "1.9.25"
+kotlin = "2.0.21"
 coreKtx = "1.13.1"
 gms = "4.4.2"
 kotlinxCoroutinesTest = "1.6.4"
@@ -22,6 +22,8 @@ lifecycleRuntimeKtx = "2.8.6"
 kaspresso = "1.5.5"
 materialIconsExtended = "1.7.3"
 robolectric = "4.13"
+roomCompiler = "2.5.0"
+roomRuntime = "2.6.1"
 sonar = "4.4.1.3373"
 cucumber = "7.19.0"
 firebaseAuth = "23.0.0"
@@ -60,6 +62,10 @@ androidx-databinding-runtime = { module = "androidx.databinding:databinding-runt
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferencesCore" }
 androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastorePreferencesCore" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }
+androidx-room-compiler-v250 = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
 calendar = { module = "com.maxkeppeler.sheets-compose-dialogs:calendar", version.ref = "calendar" }
 compose-ratingbar = { module = "com.github.a914-gowtham:compose-ratingbar", version.ref = "composeRatingbar" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -128,3 +134,4 @@ jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "k
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 sonar = { id = "org.sonarqube", version.ref = "sonar" }
 gms = { id = "com.google.gms.google-services", version.ref = "gms" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
Here is yet another _**Offline Mode**_ centered PR 😄. This time, for large _(large with respect to it size at least)_ data.

This PR aims at making the _**Offline Mode**_ more robust and more complete with full chat and message caching.

_**Feature Overview:**_
- Chat data caching
- Message serialization and storage¹

_**Commit history:**_
`task: update dependencies to use Room`²
- [x] Update dependencies to include `Room`
- [x] Update dependencies to include `ksp` for serialization
- [x] Update `kotlin` version to `2.0.21` to support `ksp`
- [x] Add [compose compiler](https://developer.android.com/develop/ui/compose/compiler) plugin for compatibility
- [x] Prepare necessary classes for chat caching

 `task: update chat logic to include room usage`
- [x] Update repository to seamlessly query from cache before falling back on `Firestore` in case of failure
- [x] Update view model to reflect repository changes

`test: test the chat caching and format`
- [x] Add tests
- [x] ktfmt format

###### ¹: For the moment, every single message is cached, which is obviously not good as it might flood the phone storage (kinda like what _WhatsApp_ does...).

###### ²: Small oopsie on my end, didn't separate the addition of the dependencies and the creation of `ChatEntity`, `ChatDao`... in different commits 😅.