### PR TITLE
Implement EarningsWidget

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/home/EarningsWidgetTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/home/EarningsWidgetTest.kt
@@ -1,0 +1,67 @@
+package com.arygm.quickfix.ui.home
+
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.arygm.quickfix.ui.uiMode.appContentUI.workerMode.home.EarningsWidget
+import org.junit.Rule
+import org.junit.Test
+
+class EarningsWidgetTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun earningsWidget_showsCorrectValues() {
+    val personalBalance = 1234.56
+    val earningsThisMonth = 456.78
+    val avgSellingPrice = 789.12
+    val activeOrders = 3
+    val activeOrderValue = 150.50
+
+    composeTestRule.setContent {
+      EarningsWidget(
+          personalBalance = personalBalance,
+          earningsThisMonth = earningsThisMonth,
+          avgSellingPrice = avgSellingPrice,
+          activeOrders = activeOrders,
+          activeOrderValue = activeOrderValue)
+    }
+
+    // Test Header
+    composeTestRule.onNodeWithTag("EarningsTitle").assertExists().assertTextEquals("Earnings")
+
+    // Test Left Column
+    composeTestRule.onNodeWithTag("PersonalBalanceLabel").assertTextEquals("Personal balance")
+    composeTestRule.onNodeWithTag("PersonalBalanceValue").assertTextContains("1234.56CHF")
+
+    composeTestRule.onNodeWithTag("AvgSellingPriceLabel").assertTextEquals("Avg. selling price")
+    composeTestRule.onNodeWithTag("AvgSellingPriceValue").assertTextContains("789.12CHF")
+
+    // Test Right Column
+    composeTestRule.onNodeWithTag("EarningsThisMonthLabel").assertTextEquals("Earning this month")
+    composeTestRule.onNodeWithTag("EarningsThisMonthValue").assertTextContains("456.78CHF")
+
+    composeTestRule.onNodeWithTag("ActiveOrdersLabel").assertTextEquals("Active orders")
+    composeTestRule
+        .onNodeWithTag("ActiveOrdersValue")
+        .assertExists()
+        .assertTextContains("3 (150.5CHF)")
+  }
+
+  @Test
+  fun earningsWidget_displaysDivider() {
+    composeTestRule.setContent {
+      EarningsWidget(
+          personalBalance = 0.0,
+          earningsThisMonth = 0.0,
+          avgSellingPrice = 0.0,
+          activeOrders = 0,
+          activeOrderValue = 0.0)
+    }
+
+    // Check that divider exists
+    composeTestRule.onNodeWithTag("EarningsDivider").assertExists()
+  }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/home/EarningsWidget.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/home/EarningsWidget.kt
@@ -1,0 +1,162 @@
+package com.arygm.quickfix.ui.uiMode.appContentUI.workerMode.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.arygm.quickfix.ui.theme.poppinsTypography
+import java.text.DecimalFormat
+
+@Composable
+fun EarningsWidget(
+    personalBalance: Double,
+    earningsThisMonth: Double,
+    avgSellingPrice: Double,
+    activeOrders: Int,
+    activeOrderValue: Double,
+) {
+  BoxWithConstraints {
+    val horizontalSpacing = maxWidth * 0.025f // 2.5% of the available width for spacing
+    val currencyFormat = DecimalFormat("######.##CHF")
+
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(horizontalSpacing)
+                .shadow(5.dp, RoundedCornerShape(20.dp))
+                .background(colorScheme.surface, RoundedCornerShape(12.dp))
+                .testTag("EarningsWidget"),
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.Start) {
+          // Header Row
+          Row(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(horizontal = 12.dp)
+                      .padding(top = 12.dp)
+                      .testTag("EarningsHeader"),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "Earnings",
+                    style = poppinsTypography.headlineMedium,
+                    fontSize = 19.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = colorScheme.onBackground,
+                    modifier = Modifier.testTag("EarningsTitle"))
+              }
+
+          HorizontalDivider(
+              thickness = 1.dp,
+              color = colorScheme.onSurface.copy(alpha = 0.2f),
+              modifier = Modifier.padding(vertical = 8.dp).testTag("EarningsDivider"))
+
+          // Content Rows
+          Row(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(horizontal = 12.dp)
+                      .padding(bottom = 12.dp)
+                      .testTag("EarningsContent"),
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.SpaceBetween) {
+                Column(modifier = Modifier.testTag("LeftColumn")) {
+                  Text(
+                      text = "Personal balance",
+                      style = poppinsTypography.labelSmall,
+                      fontSize = 10.sp,
+                      modifier = Modifier.testTag("PersonalBalanceLabel"))
+                  Text(
+                      text = currencyFormat.format(personalBalance),
+                      style = poppinsTypography.headlineMedium,
+                      fontSize = 16.sp,
+                      color = colorScheme.primary,
+                      modifier = Modifier.testTag("PersonalBalanceValue"))
+
+                  Spacer(modifier = Modifier.height(8.dp))
+
+                  Text(
+                      text = "Avg. selling price",
+                      style = poppinsTypography.labelSmall,
+                      fontSize = 10.sp,
+                      modifier = Modifier.testTag("AvgSellingPriceLabel"))
+                  Text(
+                      text = currencyFormat.format(avgSellingPrice),
+                      style = poppinsTypography.headlineMedium,
+                      fontSize = 16.sp,
+                      color = colorScheme.onBackground,
+                      modifier = Modifier.testTag("AvgSellingPriceValue"))
+                }
+
+                Column(modifier = Modifier.testTag("RightColumn")) {
+                  Text(
+                      text = "Earning this month",
+                      style = poppinsTypography.labelSmall,
+                      fontSize = 10.sp,
+                      modifier = Modifier.testTag("EarningsThisMonthLabel"))
+
+                  Text(
+                      text = currencyFormat.format(earningsThisMonth),
+                      style = poppinsTypography.headlineMedium,
+                      fontSize = 16.sp,
+                      color = colorScheme.onBackground,
+                      modifier = Modifier.testTag("EarningsThisMonthValue"))
+
+                  Spacer(modifier = Modifier.height(8.dp))
+
+                  Text(
+                      text = "Active orders",
+                      style = poppinsTypography.labelSmall,
+                      fontSize = 10.sp,
+                      modifier = Modifier.testTag("ActiveOrdersLabel"))
+
+                  StyledActiveOrders(
+                      count = activeOrders,
+                      amount = currencyFormat.format(activeOrderValue),
+                      modifier = Modifier.testTag("ActiveOrdersValue"))
+                }
+              }
+        }
+  }
+}
+
+@Composable
+fun StyledActiveOrders(count: Int, amount: String, modifier: Modifier = Modifier) {
+  val styledText: AnnotatedString = buildAnnotatedString {
+    append("$count ")
+    addStyle(style = SpanStyle(color = colorScheme.onBackground), start = 0, end = "$count".length)
+    append("($amount)")
+    addStyle(
+        style = SpanStyle(color = Color.Gray),
+        start = "$count ".length,
+        end = "$count ($amount)".length)
+  }
+
+  Text(
+      text = styledText,
+      style = poppinsTypography.headlineMedium,
+      fontSize = 16.sp,
+      letterSpacing = (-0.5).sp,
+      modifier = modifier)
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/home/EarningsWidget.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/home/EarningsWidget.kt
@@ -37,15 +37,17 @@ fun EarningsWidget(
     activeOrderValue: Double,
 ) {
   BoxWithConstraints {
-    val horizontalSpacing = maxWidth * 0.025f // 2.5% of the available width for spacing
+    val maxWidth = maxWidth
+    val maxHeight = maxHeight
     val currencyFormat = DecimalFormat("######.##CHF")
 
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .padding(horizontalSpacing)
-                .shadow(5.dp, RoundedCornerShape(20.dp))
-                .background(colorScheme.surface, RoundedCornerShape(12.dp))
+                .padding(maxWidth * 0.025f)
+                .shadow(
+                    maxWidth * 0.01f, RoundedCornerShape(maxWidth * 0.05f)) // Shadow size dynamic
+                .background(colorScheme.surface, RoundedCornerShape(maxWidth * 0.03f))
                 .testTag("EarningsWidget"),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.Start) {
@@ -53,8 +55,8 @@ fun EarningsWidget(
           Row(
               modifier =
                   Modifier.fillMaxWidth()
-                      .padding(horizontal = 12.dp)
-                      .padding(top = 12.dp)
+                      .padding(horizontal = maxWidth * 0.03f)
+                      .padding(top = maxHeight * 0.01f)
                       .testTag("EarningsHeader"),
               horizontalArrangement = Arrangement.SpaceBetween,
               verticalAlignment = Alignment.CenterVertically) {
@@ -70,14 +72,14 @@ fun EarningsWidget(
           HorizontalDivider(
               thickness = 1.dp,
               color = colorScheme.onSurface.copy(alpha = 0.2f),
-              modifier = Modifier.padding(vertical = 8.dp).testTag("EarningsDivider"))
+              modifier = Modifier.padding(vertical = maxHeight * 0.01f).testTag("EarningsDivider"))
 
           // Content Rows
           Row(
               modifier =
                   Modifier.fillMaxWidth()
-                      .padding(horizontal = 12.dp)
-                      .padding(bottom = 12.dp)
+                      .padding(horizontal = maxWidth * 0.03f)
+                      .padding(bottom = maxHeight * 0.01f)
                       .testTag("EarningsContent"),
               verticalAlignment = Alignment.CenterVertically,
               horizontalArrangement = Arrangement.SpaceBetween) {
@@ -94,7 +96,7 @@ fun EarningsWidget(
                       color = colorScheme.primary,
                       modifier = Modifier.testTag("PersonalBalanceValue"))
 
-                  Spacer(modifier = Modifier.height(8.dp))
+                  Spacer(modifier = Modifier.height(maxHeight * 0.01f))
 
                   Text(
                       text = "Avg. selling price",
@@ -115,15 +117,14 @@ fun EarningsWidget(
                       style = poppinsTypography.labelSmall,
                       fontSize = 10.sp,
                       modifier = Modifier.testTag("EarningsThisMonthLabel"))
-
                   Text(
                       text = currencyFormat.format(earningsThisMonth),
                       style = poppinsTypography.headlineMedium,
-                      fontSize = 16.sp,
                       color = colorScheme.onBackground,
+                      fontSize = 16.sp,
                       modifier = Modifier.testTag("EarningsThisMonthValue"))
 
-                  Spacer(modifier = Modifier.height(8.dp))
+                  Spacer(modifier = Modifier.height(maxHeight * 0.01f))
 
                   Text(
                       text = "Active orders",
@@ -156,7 +157,7 @@ fun StyledActiveOrders(count: Int, amount: String, modifier: Modifier = Modifier
   Text(
       text = styledText,
       style = poppinsTypography.headlineMedium,
-      fontSize = 16.sp,
+      fontSize = 16.sp, // Keep the font size static here unless needed dynamic
       letterSpacing = (-0.5).sp,
       modifier = modifier)
 }


### PR DESCRIPTION
## Description

This PR implements the **EarningsWidget** as part of the Worker HomeScreen in the QuickFix app. The **EarningsWidget** displays key earning statistics for the worker, including:

- Personal balance
- Earnings this month
- Average selling price
- Active orders with their total value

Additionally, this PR includes comprehensive **unit tests** to ensure correct rendering and behavior of the `EarningsWidget`.

---

## Changes Implemented

1. **EarningsWidget Implementation**
   - Displays detailed earning statistics:
     - Personal balance
     - Earnings this month
     - Average selling price
     - Active orders with their respective values
   - Added `testTag`s to key components for easier UI testing.

2. **Unit Tests**
   - Added tests to verify that the `EarningsWidget` renders correctly with sample data.

---

## Screenshot

<img width="326" alt="Capture d’écran 2024-12-17 à 00 17 29" src="https://github.com/user-attachments/assets/3c8908f4-2887-46c4-b7fb-b3ef921b6c5b" />

---

## Testing

### Manual Testing
- Verified that the **EarningsWidget** displays all required data correctly.
- Ensured proper formatting for currency and active order values.
- Confirmed visual alignment and spacing.

### Automated Tests
- Added unit tests for `EarningsWidget`:
   - Verified that all data fields are rendered correctly.
---

## Checklist

- [x] Implement **EarningsWidget** to display earning statistics.
- [x] Add `testTag`s to key components for UI testing.
- [x] Write unit tests for `EarningsWidget`.
- [x] Validate correct data rendering and formatting.
- [x] Achieve at least 80% test coverage.
