### PR TITLE
Add Detailed Announcement View

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementDetailTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementDetailTest.kt
@@ -1,95 +1,324 @@
 package com.arygm.quickfix.ui.search
 
-import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasText
+import android.graphics.Bitmap
+import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.arygm.quickfix.model.category.Category
+import com.arygm.quickfix.model.category.CategoryViewModel
+import com.arygm.quickfix.model.offline.small.PreferencesRepository
+import com.arygm.quickfix.model.offline.small.PreferencesViewModel
+import com.arygm.quickfix.model.profile.ProfileRepository
+import com.arygm.quickfix.model.profile.UserProfile
+import com.arygm.quickfix.model.search.Announcement
+import com.arygm.quickfix.model.search.AnnouncementRepository
 import com.arygm.quickfix.model.search.AnnouncementViewModel
+import com.arygm.quickfix.model.search.AvailabilitySlot
 import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.uiMode.appContentUI.userModeUI.search.AnnouncementDetailScreen
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDate
+import java.util.Date
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
 
 class AnnouncementDetailTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  // Mocked dependencies
   private lateinit var navigationActions: NavigationActions
+  private lateinit var mockAnnouncementRepository: AnnouncementRepository
+  private lateinit var mockPreferencesRepository: PreferencesRepository
+  private lateinit var mockProfileRepository: ProfileRepository
+
+  // Real AnnouncementViewModel with mocked repositories
   private lateinit var announcementViewModel: AnnouncementViewModel
+  private lateinit var preferencesViewModel: PreferencesViewModel
+  private lateinit var categoryViewModel: CategoryViewModel
+
+  // DataStore preference flows
+  private val userIdFlow = MutableStateFlow("testUserId")
+  private val appModeFlow = MutableStateFlow("USER") // "USER" or "WORKER"
+
+  // Sample announcement for testing
+  private val sampleAnnouncement =
+      Announcement(
+          announcementId = "testAnnouncementId",
+          userId = "testUserId",
+          title = "Test Announcement",
+          category = "subCatId",
+          description = "This is a test description",
+          location = null,
+          availability = emptyList(),
+          quickFixImages = emptyList())
+
+  // Maps announcementId -> List of (URL, Bitmap)
+  private val imagesMap = mutableMapOf<String, List<Pair<String, Bitmap>>>()
 
   @Before
   fun setup() {
-    // Mock NavigationActions and ViewModel
-    navigationActions = mock(NavigationActions::class.java)
-    announcementViewModel = mock(AnnouncementViewModel::class.java)
+    navigationActions = Mockito.mock(NavigationActions::class.java)
+
+    // Mock repositories
+    mockAnnouncementRepository = Mockito.mock(AnnouncementRepository::class.java)
+    mockPreferencesRepository = Mockito.mock(PreferencesRepository::class.java)
+    mockProfileRepository = Mockito.mock(ProfileRepository::class.java)
+
+    categoryViewModel = mockk(relaxed = true)
+
+    // PreferencesViewModel
+    preferencesViewModel = PreferencesViewModel(mockPreferencesRepository)
+
+    // Mock DataStore calls
+    val userIdKey = stringPreferencesKey("user_id")
+    val appModeKey = stringPreferencesKey("app_mode")
+    whenever(mockPreferencesRepository.getPreferenceByKey(userIdKey)).thenReturn(userIdFlow)
+    whenever(mockPreferencesRepository.getPreferenceByKey(appModeKey)).thenReturn(appModeFlow)
+
+    // Mock Profile fetch
+    doAnswer { invocation ->
+          val onSuccess = invocation.arguments[1] as (Any?) -> Unit
+          onSuccess(UserProfile(emptyList(), emptyList(), 0.0, "testUserId", emptyList()))
+          null
+        }
+        .whenever(mockProfileRepository)
+        .getProfileById(any(), any(), any())
+
+    // Initialize AnnouncementViewModel with real logic but mocked repos
+    announcementViewModel =
+        AnnouncementViewModel(
+            announcementRepository = mockAnnouncementRepository,
+            preferencesRepository = mockPreferencesRepository,
+            userProfileRepository = mockProfileRepository)
+
+    // Select the sample announcement
+    announcementViewModel.selectAnnouncement(sampleAnnouncement)
+    // Pre-populate images map with an empty list (no images initially)
+    imagesMap[sampleAnnouncement.announcementId] = emptyList()
+    announcementViewModel.setAnnouncementImagesMap(imagesMap.toMutableMap())
+
+    // Mock CategoryViewModel success call, matching your Category data class
+    every { categoryViewModel.getCategoryBySubcategoryId(any(), any()) } answers
+        {
+          secondArg<(Category?) -> Unit>()
+              .invoke(
+                  Category(
+                      id = "catId",
+                      name = "Fake Category",
+                      description = "A test category description",
+                      subcategories = emptyList()))
+        }
   }
 
   @Test
-  fun announcementDetailScreen_displaysTopAppBarWithTitle() {
+  fun announcementDetailScreen_displaysProperly_whenAnnouncementSelected() {
     composeTestRule.setContent {
       AnnouncementDetailScreen(
-          announcementViewModel = announcementViewModel, navigationActions = navigationActions)
+          announcementViewModel = announcementViewModel,
+          categoryViewModel = categoryViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
     }
 
-    // Verify that the Top App Bar is displayed
-    composeTestRule.onNodeWithTag("AnnouncementDetailTopBarTitle").assertIsDisplayed()
+    // Verify root container is displayed
+    composeTestRule.onNodeWithTag("AnnouncementDetailScreenRoot").assertExists()
+    // Verify LazyColumn is displayed
+    composeTestRule.onNodeWithTag("AnnouncementDetailLazyColumn").assertExists()
+    // Verify content column
+    composeTestRule.onNodeWithTag("AnnouncementContentColumn").assertExists()
 
-    // Verify the Top App Bar Title text
+    // Check the announcement title
+    composeTestRule.onNodeWithTag("AnnouncementTitle").assertTextEquals("Test Announcement")
+  }
+
+  @Test
+  fun goBackButtonNavigatesCorrectly() {
+    composeTestRule.setContent {
+      AnnouncementDetailScreen(
+          announcementViewModel = announcementViewModel,
+          categoryViewModel = categoryViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
+    }
+    composeTestRule.onNodeWithTag("GoBackIconBtn").performClick()
+    Mockito.verify(navigationActions).goBack()
+  }
+
+  @Test
+  fun editDeleteIconBtn_togglesIsEditing_andDeletesAnnouncement() {
+    composeTestRule.setContent {
+      AnnouncementDetailScreen(
+          announcementViewModel = announcementViewModel,
+          categoryViewModel = categoryViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
+    }
+    // First click on "EditDeleteIconBtn" turns editing ON
+    composeTestRule.onNodeWithTag("EditDeleteIconBtn").performClick()
+
+    // Now in editing mode. Click again => should delete the announcement
+    composeTestRule.onNodeWithTag("EditDeleteIconBtn").performClick()
+
+    // Verify that the repository's deleteAnnouncementById was called
+    Mockito.verify(mockAnnouncementRepository)
+        .deleteAnnouncementById(eq("testAnnouncementId"), any(), any())
+    // Also verify the viewModel unselects it
+    assert(announcementViewModel.selectedAnnouncement.value == null)
+  }
+
+  @Test
+  fun bannerTextIsDisplayed_whenImagesArePresent() {
+    // Add images to the imagesMap
+    val dummyBitmap = createMockBitmap()
+    val updatedImages = listOf("imgUrl1" to dummyBitmap, "imgUrl2" to dummyBitmap)
+    imagesMap[sampleAnnouncement.announcementId] = updatedImages
+    announcementViewModel.setAnnouncementImagesMap(imagesMap.toMutableMap())
+
+    composeTestRule.setContent {
+      AnnouncementDetailScreen(
+          announcementViewModel = announcementViewModel,
+          categoryViewModel = categoryViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
+    }
+
+    // The banner should read "1 of 2"
+    composeTestRule.onNodeWithTag("BannerText", useUnmergedTree = true).assertTextEquals("1 of 2")
+  }
+
+  @Test
+  fun locationFallbackDisplayed_whenLocationIsNull() {
+    composeTestRule.setContent {
+      AnnouncementDetailScreen(
+          announcementViewModel = announcementViewModel,
+          categoryViewModel = categoryViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
+    }
+    composeTestRule.onNodeWithTag("LocationValue").assertTextEquals("No location available")
+  }
+
+  @Test
+  fun availabilitySlotsDisplayed_whenNotEmpty() {
+    // Provide some availability
+    val updatedAnnouncement =
+        sampleAnnouncement.copy(
+            availability =
+                listOf(
+                    AvailabilitySlot(
+                        start = com.google.firebase.Timestamp(Date(1680000000000)),
+                        end = com.google.firebase.Timestamp(Date(1680003600000)))))
+    announcementViewModel.selectAnnouncement(updatedAnnouncement)
+
+    composeTestRule.setContent {
+      AnnouncementDetailScreen(
+          announcementViewModel = announcementViewModel,
+          categoryViewModel = categoryViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
+    }
+
+    // The header row should appear
+    composeTestRule.onNodeWithTag("AvailabilityHeader").assertExists()
+    // The slot row should appear
+    composeTestRule.onNodeWithTag("AvailabilitySlot_0").assertExists()
+  }
+
+  @Test
+  fun emptyAvailabilityFallback_whenNoSlots() {
+    // sampleAnnouncement has an empty availability list by default
+    composeTestRule.setContent {
+      AnnouncementDetailScreen(
+          announcementViewModel = announcementViewModel,
+          categoryViewModel = categoryViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
+    }
+    // Fallback
+    composeTestRule.onNodeWithTag("EmptyAvailabilityBox").assertIsDisplayed()
+  }
+
+  @Test
+  fun enableEditing_showsUpdateAnnouncementBtn_clickingItCallsUpdate_andNavigatesBack() {
+    composeTestRule.setContent {
+      AnnouncementDetailScreen(
+          announcementViewModel = announcementViewModel,
+          categoryViewModel = categoryViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
+    }
+
+    // Turn editing on
+    composeTestRule.onNodeWithTag("EditDeleteIconBtn").performClick()
+
+    // Now we need to simulate the user *changing the description* so that descriptionChanged = true
     composeTestRule
-        .onNodeWithTag("AnnouncementDetailTopBarTitle")
-        .assertIsDisplayed()
-        .assert(hasText("Announcement Detail"))
-  }
-
-  @Test
-  fun announcementDetailScreen_displaysCenteredText() {
-    composeTestRule.setContent {
-      AnnouncementDetailScreen(
-          announcementViewModel = announcementViewModel, navigationActions = navigationActions)
-    }
-
-    // Verify that the centered text is displayed
-    composeTestRule.onNodeWithTag("AnnoucementDetailTitle").assertIsDisplayed()
-
-    // Verify the centered text content
+        .onNodeWithTag("DescriptionTextField", useUnmergedTree = true)
+        .performTextClearance() // Clear existing text
     composeTestRule
-        .onNodeWithTag("AnnoucementDetailTitle")
+        .onNodeWithTag("DescriptionTextField", useUnmergedTree = true)
+        .performTextInput("New description") // Type something new
+
+    // "UpdateAnnouncementBtn" is now visible
+    composeTestRule.onNodeWithTag("UpdateAnnouncementBtn").assertExists()
+    // Click it
+    composeTestRule.onNodeWithTag("UpdateAnnouncementBtn").performClick()
+
+    // Now, updateAnnouncement(...) should have been called
+    Mockito.verify(mockAnnouncementRepository).updateAnnouncement(any(), any(), any())
+    Mockito.verify(navigationActions).goBack()
+  }
+
+  @Test
+  fun proposeQuickFixBtn_isShown_whenAppModeIsWorker() {
+    // Switch app mode to "WORKER"
+    appModeFlow.value = "WORKER"
+
+    composeTestRule.setContent {
+      AnnouncementDetailScreen(
+          announcementViewModel = announcementViewModel,
+          categoryViewModel = categoryViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
+    }
+
+    // "EditDeleteIconBtn" should not exist
+    composeTestRule.onNodeWithTag("EditDeleteIconBtn").assertDoesNotExist()
+    // "ProposeQuickFixBtn" should be visible
+    composeTestRule.onNodeWithTag("ProposeQuickFixBtn").assertIsDisplayed()
+  }
+
+  @Test
+  fun addAvailability_displaysDatePicker() {
+
+    composeTestRule.setContent {
+      AnnouncementDetailScreen(
+          announcementViewModel = announcementViewModel,
+          preferencesViewModel = preferencesViewModel,
+          navigationActions = navigationActions)
+    }
+
+    // Act - Turn on editing mode
+    composeTestRule.onNodeWithTag("EditDeleteIconBtn").performClick()
+    composeTestRule.onNodeWithTag("AddNewAvailabilityBtn").assertExists().performClick()
+
+    // Assert - Start Availability Picker is displayed
+    val date = LocalDate.now()
+    composeTestRule
+        .onNode(hasText(date.dayOfMonth.toString()) and hasClickAction())
         .assertIsDisplayed()
-        .assert(hasText("Announcement Detail"))
   }
 
-  @Test
-  fun announcementDetailScreen_goBackButtonWorks() {
-    composeTestRule.setContent {
-      AnnouncementDetailScreen(
-          announcementViewModel = announcementViewModel, navigationActions = navigationActions)
-    }
-
-    // Verify that the Go Back button exists
-    composeTestRule.onNodeWithTag("GoBackButton").assertIsDisplayed()
-
-    // Perform a click on the Go Back button
-    composeTestRule.onNodeWithTag("GoBackButton").performClick()
-
-    // Verify that navigationActions.goBack() is triggered
-    verify(navigationActions).goBack()
-  }
-
-  @Test
-  fun announcementDetailScreen_fullLayoutRendersCorrectly() {
-    composeTestRule.setContent {
-      AnnouncementDetailScreen(
-          announcementViewModel = announcementViewModel, navigationActions = navigationActions)
-    }
-
-    // Verify all key components exist and are displayed
-    composeTestRule.onNodeWithTag("AnnouncementDetailScreen").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("GoBackButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("AnnouncementDetailTopBarTitle").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("AnnoucementDetailTitle").assertIsDisplayed()
+  private fun createMockBitmap(): Bitmap {
+    return Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
   }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/UserModeNavGraph.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/UserModeNavGraph.kt
@@ -353,7 +353,8 @@ fun DashBoardNavHost(
           categoryViewModel)
     }
     composable(UserScreen.ANNOUNCEMENT_DETAIL) {
-      AnnouncementDetailScreen(announcementViewModel, navigationActions)
+      AnnouncementDetailScreen(
+          announcementViewModel, categoryViewModel, preferencesViewModel, navigationActions)
     }
     composable(UserScreen.DISPLAY_UPLOADED_IMAGES) {
       QuickFixDisplayImages(navigationActions, preferencesViewModel, announcementViewModel)

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/search/AnnouncementDetail.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/search/AnnouncementDetail.kt
@@ -1,63 +1,467 @@
 package com.arygm.quickfix.ui.uiMode.appContentUI.userModeUI.search
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.outlined.ElectricalServices
+import androidx.compose.material3.*
 import androidx.compose.material3.MaterialTheme.colorScheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.arygm.quickfix.R
+import com.arygm.quickfix.model.category.Category
+import com.arygm.quickfix.model.category.CategoryViewModel
+import com.arygm.quickfix.model.category.getCategoryIcon
+import com.arygm.quickfix.model.offline.small.PreferencesViewModel
 import com.arygm.quickfix.model.search.AnnouncementViewModel
+import com.arygm.quickfix.model.search.AvailabilitySlot
+import com.arygm.quickfix.model.switchModes.AppMode
+import com.arygm.quickfix.ui.elements.QuickFixButton
+import com.arygm.quickfix.ui.elements.QuickFixTextFieldCustom
 import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.theme.poppinsTypography
+import com.arygm.quickfix.ui.uiMode.appContentUI.userModeUI.navigation.UserScreen
+import com.arygm.quickfix.utils.loadAppMode
+import java.text.SimpleDateFormat
+import java.util.Locale
 
-@OptIn(ExperimentalMaterial3Api::class)
+private const val PADDING_BETWEEN_ELEM = 8
+
 @Composable
 fun AnnouncementDetailScreen(
     announcementViewModel: AnnouncementViewModel,
+    categoryViewModel: CategoryViewModel = viewModel(factory = CategoryViewModel.Factory),
+    preferencesViewModel: PreferencesViewModel,
     navigationActions: NavigationActions,
 ) {
-  Box(
-      modifier = Modifier.fillMaxSize().testTag("AnnouncementDetailScreen"),
-      contentAlignment = Alignment.Center) {
-        Column {
-          // Top App Bar with Go Back button
-          TopAppBar(
-              title = {
-                Text(
-                    text = "Announcement Detail",
-                    color = colorScheme.primary,
-                    style = poppinsTypography.headlineMedium,
-                    modifier = Modifier.testTag("AnnouncementDetailTopBarTitle"))
-              },
-              navigationIcon = {
-                IconButton(
-                    onClick = { navigationActions.goBack() },
-                    modifier = Modifier.testTag("GoBackButton")) {
-                      Icon(
-                          imageVector = Icons.Default.ArrowBack,
-                          contentDescription = "Go Back",
-                          tint = colorScheme.primary)
-                    }
-              },
-              modifier = Modifier.fillMaxWidth())
+  var isUser by remember { mutableStateOf(true) }
+  LaunchedEffect(Unit) { isUser = loadAppMode(preferencesViewModel) == AppMode.USER.name }
+  BoxWithConstraints {
+    val widthRatio = maxWidth / 411
+    val heightRatio = maxHeight / 860
+    val sizeRatio = minOf(widthRatio, heightRatio)
 
-          // Centered Text
-          Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(
-                modifier = Modifier.testTag("AnnoucementDetailTitle"),
-                text = "Announcement Detail",
-                style = poppinsTypography.headlineLarge)
-          }
-        }
+    val selectedAnnouncement by announcementViewModel.selectedAnnouncement.collectAsState()
+    val imagesMap by announcementViewModel.announcementImagesMap.collectAsState()
+
+    if (selectedAnnouncement != null) {
+      val announcement = selectedAnnouncement!!
+      var category by remember { mutableStateOf(Category()) }
+      LaunchedEffect(Unit) {
+        categoryViewModel.getCategoryBySubcategoryId(
+            announcement.category,
+            onSuccess = {
+              if (it != null) {
+                category = it
+              }
+            })
       }
+
+      val description = remember { mutableStateOf(announcement.description) }
+      var descriptionError by remember { mutableStateOf(false) }
+      val images = imagesMap[announcement.announcementId] ?: emptyList()
+      val bannerText = if (images.isNotEmpty()) "1 of ${images.size}" else null
+
+      var isEditing by remember { mutableStateOf(false) }
+      val dates = remember {
+        mutableStateListOf<AvailabilitySlot>().apply { addAll(announcement.availability) }
+      }
+
+      Box(
+          modifier =
+              Modifier.fillMaxSize()
+                  .background(color = colorScheme.surface)
+                  .align(Alignment.Center)) {
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(PADDING_BETWEEN_ELEM.dp)) {
+                  item {
+                    // Top Image Section
+                    Box(
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .height(200.dp * heightRatio.value)
+                                .clip(
+                                    RoundedCornerShape(
+                                        bottomStart = 10.dp * sizeRatio.value,
+                                        bottomEnd =
+                                            10.dp * sizeRatio.value)) // Rounded bottom corners
+                                .background(Color.Gray)
+                                .clickable {
+                                  navigationActions.navigateTo(UserScreen.DISPLAY_UPLOADED_IMAGES)
+                                }) {
+                          // Display the first image or a placeholder
+                          if (images.isNotEmpty()) {
+                            Image(
+                                bitmap = images.first().second.asImageBitmap(),
+                                contentDescription = "Announcement Image",
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.fillMaxSize())
+                          }
+
+                          // Back button
+                          IconButton(
+                              onClick = { navigationActions.goBack() },
+                              modifier =
+                                  Modifier.size(50.dp * sizeRatio.value)
+                                      .align(Alignment.TopStart)
+                                      .clip(CircleShape)
+                                      .padding(PADDING_BETWEEN_ELEM.dp * sizeRatio.value)
+                                      .background(colorScheme.surface, shape = CircleShape)
+                                      .padding(
+                                          horizontal = PADDING_BETWEEN_ELEM.dp * sizeRatio.value,
+                                          vertical = 4.dp * sizeRatio.value)) {
+                                Icon(
+                                    imageVector = Icons.Default.ArrowBack,
+                                    contentDescription = "Go Back",
+                                    tint = colorScheme.primary)
+                              }
+
+                          // Edit/Delete button (only for users)
+                          if (isUser) {
+                            IconButton(
+                                onClick = {
+                                  if (isEditing) { // Can delete
+                                    announcementViewModel.deleteAnnouncementById(
+                                        announcement.announcementId)
+                                    announcementViewModel.unselectAnnouncement()
+                                    navigationActions.goBack()
+                                  } else { // Start editing
+                                    isEditing = !isEditing
+                                  }
+                                },
+                                modifier =
+                                    Modifier.size(50.dp * sizeRatio.value)
+                                        .align(Alignment.TopEnd)
+                                        .clip(CircleShape)
+                                        .padding(PADDING_BETWEEN_ELEM.dp * sizeRatio.value)
+                                        .background(colorScheme.surface, shape = CircleShape)
+                                        .padding(
+                                            horizontal = PADDING_BETWEEN_ELEM.dp * sizeRatio.value,
+                                            vertical = 4.dp * sizeRatio.value)) {
+                                  Icon(
+                                      painter =
+                                          if (isEditing) painterResource(id = R.drawable.delete)
+                                          else painterResource(id = R.drawable.edit),
+                                      contentDescription = if (isEditing) "Delete" else "Edit",
+                                      tint = colorScheme.primary)
+                                }
+                          }
+
+                          // Banner for number of images
+                          bannerText?.let {
+                            Text(
+                                text = it,
+                                style = poppinsTypography.bodyMedium.copy(fontSize = 12.sp),
+                                fontWeight = FontWeight.Normal,
+                                color = colorScheme.onSurface,
+                                modifier =
+                                    Modifier.align(Alignment.BottomEnd)
+                                        .padding(PADDING_BETWEEN_ELEM.dp * sizeRatio.value)
+                                        .background(
+                                            colorScheme.surface,
+                                            RoundedCornerShape(4.dp * sizeRatio.value))
+                                        .padding(
+                                            horizontal = PADDING_BETWEEN_ELEM.dp * sizeRatio.value,
+                                            vertical = 4.dp * sizeRatio.value))
+                          }
+                        }
+                  }
+                  item {
+                    // Content Section
+                    Column(
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .padding(
+                                    horizontal = 16.dp * sizeRatio.value) // Add padding for content
+                        ) {
+                          // Announcement Title
+                          Row(
+                              modifier = Modifier.fillMaxWidth(),
+                              verticalAlignment = Alignment.CenterVertically) {
+                                // Title Text
+                                Text(
+                                    text = announcement.title,
+                                    style = poppinsTypography.titleMedium.copy(fontSize = 22.sp),
+                                    color = colorScheme.onBackground,
+                                    fontWeight = FontWeight.Bold,
+                                )
+
+                                Spacer(modifier = Modifier.width(30.dp * widthRatio.value))
+
+                                Icon(
+                                    imageVector = getCategoryIcon(category),
+                                    contentDescription = "Category Icon",
+                                    tint = colorScheme.primary,
+                                    modifier =
+                                        Modifier.testTag("CategoryIconForSelectedAnnouncement"))
+                              }
+
+                          Spacer(
+                              modifier =
+                                  Modifier.height(PADDING_BETWEEN_ELEM.dp * heightRatio.value))
+
+                          // Description
+                          QuickFixTextFieldCustom(
+                              modifier = Modifier.semantics { testTag = "descriptionHolder" },
+                              widthField = 380.dp * widthRatio.value,
+                              value = description.value,
+                              onValueChange = { description.value = it },
+                              textColor = colorScheme.onSurface,
+                              shape = RoundedCornerShape(PADDING_BETWEEN_ELEM.dp),
+                              showLabel = true,
+                              label = {
+                                Text(
+                                    text = "Description",
+                                    style =
+                                        poppinsTypography.headlineMedium.copy(
+                                            fontSize = 12.sp, fontWeight = FontWeight.Medium),
+                                    color = colorScheme.onBackground)
+                              },
+                              hasShadow = false,
+                              borderColor =
+                                  if (isEditing) colorScheme.tertiaryContainer
+                                  else colorScheme.surface,
+                              placeHolderText = "Type a description...",
+                              isError = descriptionError,
+                              errorText = "Please enter a description",
+                              showError = descriptionError,
+                              singleLine = false,
+                              isTextField = isEditing,
+                              enabled = isEditing,
+                              heightInEnabled = true,
+                              minHeight = 40.dp * heightRatio.value,
+                          )
+
+                          Spacer(
+                              modifier =
+                                  Modifier.height(PADDING_BETWEEN_ELEM.dp * heightRatio.value))
+                          Divider(
+                              color = colorScheme.onSurface.copy(alpha = 0.2f), thickness = 1.dp)
+                          Spacer(
+                              modifier =
+                                  Modifier.height(PADDING_BETWEEN_ELEM.dp * heightRatio.value))
+
+                          // Location Section
+                          Row(
+                              modifier =
+                                  Modifier.fillMaxWidth()
+                                      .padding(vertical = PADDING_BETWEEN_ELEM.dp),
+                              verticalAlignment = Alignment.CenterVertically) {
+                                // Location Icon
+                                Icon(
+                                    imageVector = Icons.Default.LocationOn,
+                                    contentDescription = "Location Icon",
+                                    tint = colorScheme.onSurface,
+                                    modifier =
+                                        Modifier.size(35.dp * sizeRatio.value)
+                                            .padding(end = PADDING_BETWEEN_ELEM.dp))
+
+                                Column {
+                                  // Location Title
+                                  Text(
+                                      text = "Location",
+                                      style =
+                                          poppinsTypography.headlineMedium.copy(
+                                              fontSize = 12.sp, fontWeight = FontWeight.Medium),
+                                      color = colorScheme.onBackground)
+                                  // Location Value
+                                  Text(
+                                      text = announcement.location?.name ?: "No location available",
+                                      style = MaterialTheme.typography.labelSmall,
+                                      color = colorScheme.onSurface)
+                                }
+                              }
+
+                          Spacer(
+                              modifier =
+                                  Modifier.height(PADDING_BETWEEN_ELEM.dp * heightRatio.value))
+                          Divider(
+                              color = colorScheme.onSurface.copy(alpha = 0.2f), thickness = 1.dp)
+                          Spacer(
+                              modifier =
+                                  Modifier.height(PADDING_BETWEEN_ELEM.dp * heightRatio.value))
+
+                          // Date and Time Section
+                          Row(
+                              modifier = Modifier.fillMaxWidth(),
+                              verticalAlignment = Alignment.CenterVertically) {
+                                // Calendar Icon
+                                Icon(
+                                    painter = painterResource(id = R.drawable.calendar),
+                                    contentDescription = "Calendar Icon",
+                                    tint = colorScheme.onSurface,
+                                    modifier =
+                                        Modifier.size(35.dp * sizeRatio.value)
+                                            .padding(
+                                                end =
+                                                    PADDING_BETWEEN_ELEM
+                                                        .dp) // Space between icon and text
+                                    )
+
+                                // Section Title
+                                Text(
+                                    text = "Date and time",
+                                    style =
+                                        poppinsTypography.headlineMedium.copy(
+                                            fontSize = 12.sp, fontWeight = FontWeight.Medium),
+                                    color = colorScheme.onBackground)
+                              }
+
+                          Spacer(
+                              modifier =
+                                  Modifier.height(PADDING_BETWEEN_ELEM.dp * heightRatio.value))
+
+                          // Define date and time formatters
+                          val dateFormatter = SimpleDateFormat("EEE, dd MMM", Locale.getDefault())
+                          val timeFormatter = SimpleDateFormat("hh:mm a", Locale.getDefault())
+
+                          // Availability List or Fallback Message
+                          if (dates.isNotEmpty()) {
+                            // Availability Slots Header
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween) {
+                                  Text(
+                                      text = "Day",
+                                      style =
+                                          MaterialTheme.typography.bodyMedium.copy(
+                                              fontWeight = FontWeight.Medium),
+                                      color = colorScheme.onSurface)
+                                  Text(
+                                      text = "Time",
+                                      style =
+                                          MaterialTheme.typography.bodyMedium.copy(
+                                              fontWeight = FontWeight.Medium),
+                                      color = colorScheme.onSurface)
+                                }
+
+                            Spacer(
+                                modifier =
+                                    Modifier.height(PADDING_BETWEEN_ELEM.dp * heightRatio.value))
+
+                            // Display Each Availability Slot
+                            dates.forEach { slot ->
+                              val day =
+                                  dateFormatter.format(
+                                      slot.start.toDate()) // Format date as "EEE, dd MMM"
+                              val timeRange =
+                                  "${timeFormatter.format(slot.start.toDate())} - ${
+                                            timeFormatter.format(slot.end.toDate())
+                                        }" // Format time as "hh:mm a"
+                              Row(
+                                  modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+                                  horizontalArrangement = Arrangement.SpaceBetween) {
+                                    Text(
+                                        text = day, // Displays the day
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = colorScheme.onSurface)
+                                    Text(
+                                        text = timeRange, // Displays the time range
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = colorScheme.onSurface)
+                                  }
+                            }
+                          } else {
+                            // Fallback Message for Empty Availability
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center) {
+                                  Text(
+                                      text = "Availability has not been specified",
+                                      style = MaterialTheme.typography.labelSmall,
+                                      color = colorScheme.onSurface)
+                                }
+                          }
+
+                          if (isEditing) {
+                            Text(
+                                text = "+ Add new",
+                                style =
+                                    MaterialTheme.typography.bodyMedium.copy(
+                                        color = MaterialTheme.colorScheme.primary),
+                                modifier =
+                                    Modifier.padding(top = 8.dp, start = 8.dp).clickable {
+                                      // Add a new AvailabilitySlot with default start and end times
+                                      dates.add(
+                                          AvailabilitySlot(
+                                              start = com.google.firebase.Timestamp.now(),
+                                              end = com.google.firebase.Timestamp.now()))
+                                    })
+                          }
+                        }
+                  }
+                }
+
+            // Buttons logic
+            Box(
+                modifier =
+                    Modifier.fillMaxWidth().align(Alignment.BottomCenter).padding(bottom = 16.dp)) {
+                  Row(
+                      modifier = Modifier.fillMaxWidth(),
+                      horizontalArrangement = Arrangement.Center) {
+                        if (isUser) {
+                          if (isEditing) {
+                            QuickFixButton(
+                                buttonText = "Update announcement",
+                                onClickAction = {
+                                  // Check if description or availability have changed
+                                  val descriptionChanged =
+                                      description.value != announcement.description
+                                  val availabilityChanged =
+                                      dates.toList() != announcement.availability
+
+                                  if (descriptionChanged || availabilityChanged) {
+                                    // Create a new Announcement object with updated fields
+                                    val updatedAnnouncement =
+                                        announcement.copy(
+                                            description = description.value,
+                                            availability = dates.toList())
+                                    announcementViewModel.updateAnnouncement(updatedAnnouncement)
+                                  }
+                                  announcementViewModel.unselectAnnouncement()
+                                  navigationActions.goBack()
+                                },
+                                buttonColor = colorScheme.primary,
+                                textColor = colorScheme.onPrimary,
+                                leadingIcon = Icons.Default.Edit,
+                                leadingIconTint = colorScheme.onPrimary)
+                          }
+                        } else {
+                          QuickFixButton(
+                              buttonText = "Propose a quickfix",
+                              onClickAction = {
+                                // TODO: Add the onclick action for proposing a quickfix
+                              },
+                              buttonColor = colorScheme.primary,
+                              textColor = colorScheme.onPrimary,
+                              leadingIcon = Icons.Outlined.ElectricalServices,
+                              leadingIconTint = colorScheme.onPrimary)
+                        }
+                      }
+                }
+          }
+    }
+  }
 }


### PR DESCRIPTION
#### **Summary**
This PR introduces a detailed view of an announcement, enabling users and workers to interact with posted announcements. The view supports:  
- **Users**: Update or delete their own announcements.  
- **Workers**: View the details of announcements proposed to them and propose a quickfix.

Additionally, this PR includes comprehensive **tests** to ensure the functionality of the new screen.

---

#### **Key Features**
1. **Detailed View of an Announcement**  
   - Displays the announcement's title, description, location, and availability slots.  
   - Supports image previews with a counter (e.g., "1 of X").

2. **User-Specific Capabilities**  
   - Users can **edit** the description and availability of their announcements.  
   - Users can **delete** their announcements with a single action.

3. **Worker-Specific Capabilities**  
   - Workers can view announcements and propose a quickfix.

4. **Availability Slot Management**  
   - Users can add new availability slots through a clean and interactive date-time picker.

5. **Testing**  
   - Added tests to verify editing, deleting, and availability slot addition.  
   - Ensures the UI behaves as expected for both users and workers.

---

#### **UI Preview**
1. **Default View (Worker)**  
   - Shows announcement details but does not display edit or delete options.

![Capture d'écran 2024-12-17 180511](https://github.com/user-attachments/assets/eefea772-2f6d-491a-844b-1ce361070a8c)


2. **Editable View (User)**  
   - Enables editing the description, adding availability slots, and deleting the announcement.

  
![Capture d'écran 2024-12-17 180525](https://github.com/user-attachments/assets/e292b155-1c65-4456-9401-d0f14c3e7724)


---