### PR TITLE
[Toolbox] - Add the toolbox floating button

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/kaspresso/HomeUserNoModeScreenTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/kaspresso/HomeUserNoModeScreenTest.kt
@@ -78,6 +78,7 @@ class HomeUserNoModeScreenTest : TestCase() {
       }
     }
 
+    // Step 1: Check UI elements on HomeScreen
     step("Check UI elements on HomeScreen") {
       // You can add assertions and interactions here
       ComposeScreen.onComposeScreen<HomeScreenObject>(composeTestRule) {
@@ -86,6 +87,8 @@ class HomeUserNoModeScreenTest : TestCase() {
         searchBar { assertIsDisplayed() }
       }
     }
+
+    // Step 2: Click inside the search bar to gain focus
     step("Click inside the search bar to gain focus") {
       composeTestRule.onNodeWithTag("searchBar").performClick()
     }
@@ -95,7 +98,17 @@ class HomeUserNoModeScreenTest : TestCase() {
       composeTestRule.onNodeWithTag("homeContent").performClick()
     }
 
-    // Step 4: Assert that the search bar has lost focus
+    // Step 4: Click on the floating action button to open the QuickFixToolbox
+    step("Click on the floating action button to open the QuickFixToolbox") {
+      composeTestRule.onNodeWithTag("ToolboxFloatingButton").performClick()
+    }
+
+    // Step 5: Click on the floating action button again to close the QuickFixToolbox
+    step("Click on the floating action button to open the QuickFixToolbox") {
+      composeTestRule.onNodeWithTag("ToolboxFloatingButton").performClick()
+    }
+
+    // Step 6: Assert that the search bar has lost focus
     step("Assert the search bar has lost focus") {
       composeTestRule.onNodeWithTag("searchBar").assertIsNotFocused()
     }

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixToolboxFloatingButtonTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixToolboxFloatingButtonTest.kt
@@ -19,107 +19,86 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class QuickFixToolboxFloatingButtonTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Test
-    fun mainIconIsDisplayedInitially() {
-        composeTestRule.setContent {
-            QuickFixToolboxFloatingButton(
-                iconList = listOf(Icons.Default.Work, Icons.Default.Work),
-                onIconClick = {}
-            )
-        }
-
-        // Check if the main icon is displayed
-        composeTestRule.onNodeWithTag("mainIcon")
-            .assertIsDisplayed()
-
-        // Sub icons should not be visible initially
-        composeTestRule.onAllNodes(hasTestTagPrefix("subIcon"))
-            .assertCountEquals(0)
+  @Test
+  fun mainIconIsDisplayedInitially() {
+    composeTestRule.setContent {
+      QuickFixToolboxFloatingButton(
+          iconList = listOf(Icons.Default.Work, Icons.Default.Work), onIconClick = {})
     }
 
-    @Test
-    fun clickingMainIconShowsSubIcons() {
-        val subIcons = listOf(Icons.Default.Work, Icons.Default.Work, Icons.Default.Work)
-        composeTestRule.setContent {
-            QuickFixToolboxFloatingButton(
-                iconList = subIcons,
-                onIconClick = {}
-            )
-        }
+    // Check if the main icon is displayed
+    composeTestRule.onNodeWithTag("mainIcon").assertIsDisplayed()
 
-        // Click the main icon to expand
-        composeTestRule.onNodeWithTag("mainIcon")
-            .performClick()
+    // Sub icons should not be visible initially
+    composeTestRule.onAllNodes(hasTestTagPrefix("subIcon")).assertCountEquals(0)
+  }
 
-        // Now all sub-icons should be visible
-        subIcons.indices.forEach { index ->
-            composeTestRule.onNodeWithTag("subIcon$index")
-                .assertIsDisplayed()
-        }
+  @Test
+  fun clickingMainIconShowsSubIcons() {
+    val subIcons = listOf(Icons.Default.Work, Icons.Default.Work, Icons.Default.Work)
+    composeTestRule.setContent {
+      QuickFixToolboxFloatingButton(iconList = subIcons, onIconClick = {})
     }
 
-    @Test
-    fun clickingSubIconTriggersCallback() {
-        val subIcons = listOf(Icons.Default.Work, Icons.Default.Work)
-        var clickedIndex: Int? = null
+    // Click the main icon to expand
+    composeTestRule.onNodeWithTag("mainIcon").performClick()
 
-        composeTestRule.setContent {
-            QuickFixToolboxFloatingButton(
-                iconList = subIcons,
-                onIconClick = { index ->
-                    clickedIndex = index
-                }
-            )
-        }
+    // Now all sub-icons should be visible
+    subIcons.indices.forEach { index ->
+      composeTestRule.onNodeWithTag("subIcon$index").assertIsDisplayed()
+    }
+  }
 
-        // Expand first
-        composeTestRule.onNodeWithTag("mainIcon")
-            .performClick()
+  @Test
+  fun clickingSubIconTriggersCallback() {
+    val subIcons = listOf(Icons.Default.Work, Icons.Default.Work)
+    var clickedIndex: Int? = null
 
-        // Click the first sub icon
-        composeTestRule.onNodeWithTag("subIcon0")
-            .performClick()
-
-        // Verify callback was triggered with correct index
-        assertEquals(0, clickedIndex)
+    composeTestRule.setContent {
+      QuickFixToolboxFloatingButton(
+          iconList = subIcons, onIconClick = { index -> clickedIndex = index })
     }
 
-    @Test
-    fun clickingMainIconAgainHidesSubIcons() {
-        val subIcons = listOf(Icons.Default.Work, Icons.Default.Work, Icons.Default.Work)
-        composeTestRule.setContent {
-            QuickFixToolboxFloatingButton(
-                iconList = subIcons,
-                onIconClick = {}
-            )
-        }
+    // Expand first
+    composeTestRule.onNodeWithTag("mainIcon").performClick()
 
-        // Expand the button
-        composeTestRule.onNodeWithTag("mainIcon").performClick()
+    // Click the first sub icon
+    composeTestRule.onNodeWithTag("subIcon0").performClick()
 
-        // Verify sub icons are shown
-        subIcons.indices.forEach { index ->
-            composeTestRule.onNodeWithTag("subIcon$index")
-                .assertIsDisplayed()
-        }
+    // Verify callback was triggered with correct index
+    assertEquals(0, clickedIndex)
+  }
 
-        // Collapse the button
-        composeTestRule.onNodeWithTag("mainIcon").performClick()
-
-        // Verify sub icons are no longer visible
-        composeTestRule.onAllNodes(hasTestTagPrefix("subIcon"))
-            .assertCountEquals(0)
+  @Test
+  fun clickingMainIconAgainHidesSubIcons() {
+    val subIcons = listOf(Icons.Default.Work, Icons.Default.Work, Icons.Default.Work)
+    composeTestRule.setContent {
+      QuickFixToolboxFloatingButton(iconList = subIcons, onIconClick = {})
     }
 
-    // Helper matcher for subIcon test tags
-    private fun hasTestTagPrefix(prefix: String): SemanticsMatcher {
-        return hasTestTag(ComplicationTagMatcher(prefix).toString())
+    // Expand the button
+    composeTestRule.onNodeWithTag("mainIcon").performClick()
+
+    // Verify sub icons are shown
+    subIcons.indices.forEach { index ->
+      composeTestRule.onNodeWithTag("subIcon$index").assertIsDisplayed()
     }
 
-    private fun ComplicationTagMatcher(prefix: String): (String) -> Boolean = {
-        it.startsWith(prefix)
-    }
+    // Collapse the button
+    composeTestRule.onNodeWithTag("mainIcon").performClick()
+
+    // Verify sub icons are no longer visible
+    composeTestRule.onAllNodes(hasTestTagPrefix("subIcon")).assertCountEquals(0)
+  }
+
+  // Helper matcher for subIcon test tags
+  private fun hasTestTagPrefix(prefix: String): SemanticsMatcher {
+    return hasTestTag(complicationTagMatcher(prefix).toString())
+  }
+
+  private fun complicationTagMatcher(prefix: String): (String) -> Boolean = {
+    it.startsWith(prefix)
+  }
 }

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixToolboxFloatingButtonTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixToolboxFloatingButtonTest.kt
@@ -1,0 +1,125 @@
+package com.arygm.quickfix.ui.elements
+
+import QuickFixToolboxFloatingButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Work
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class QuickFixToolboxFloatingButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun mainIconIsDisplayedInitially() {
+        composeTestRule.setContent {
+            QuickFixToolboxFloatingButton(
+                iconList = listOf(Icons.Default.Work, Icons.Default.Work),
+                onIconClick = {}
+            )
+        }
+
+        // Check if the main icon is displayed
+        composeTestRule.onNodeWithTag("mainIcon")
+            .assertIsDisplayed()
+
+        // Sub icons should not be visible initially
+        composeTestRule.onAllNodes(hasTestTagPrefix("subIcon"))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun clickingMainIconShowsSubIcons() {
+        val subIcons = listOf(Icons.Default.Work, Icons.Default.Work, Icons.Default.Work)
+        composeTestRule.setContent {
+            QuickFixToolboxFloatingButton(
+                iconList = subIcons,
+                onIconClick = {}
+            )
+        }
+
+        // Click the main icon to expand
+        composeTestRule.onNodeWithTag("mainIcon")
+            .performClick()
+
+        // Now all sub-icons should be visible
+        subIcons.indices.forEach { index ->
+            composeTestRule.onNodeWithTag("subIcon$index")
+                .assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun clickingSubIconTriggersCallback() {
+        val subIcons = listOf(Icons.Default.Work, Icons.Default.Work)
+        var clickedIndex: Int? = null
+
+        composeTestRule.setContent {
+            QuickFixToolboxFloatingButton(
+                iconList = subIcons,
+                onIconClick = { index ->
+                    clickedIndex = index
+                }
+            )
+        }
+
+        // Expand first
+        composeTestRule.onNodeWithTag("mainIcon")
+            .performClick()
+
+        // Click the first sub icon
+        composeTestRule.onNodeWithTag("subIcon0")
+            .performClick()
+
+        // Verify callback was triggered with correct index
+        assertEquals(0, clickedIndex)
+    }
+
+    @Test
+    fun clickingMainIconAgainHidesSubIcons() {
+        val subIcons = listOf(Icons.Default.Work, Icons.Default.Work, Icons.Default.Work)
+        composeTestRule.setContent {
+            QuickFixToolboxFloatingButton(
+                iconList = subIcons,
+                onIconClick = {}
+            )
+        }
+
+        // Expand the button
+        composeTestRule.onNodeWithTag("mainIcon").performClick()
+
+        // Verify sub icons are shown
+        subIcons.indices.forEach { index ->
+            composeTestRule.onNodeWithTag("subIcon$index")
+                .assertIsDisplayed()
+        }
+
+        // Collapse the button
+        composeTestRule.onNodeWithTag("mainIcon").performClick()
+
+        // Verify sub icons are no longer visible
+        composeTestRule.onAllNodes(hasTestTagPrefix("subIcon"))
+            .assertCountEquals(0)
+    }
+
+    // Helper matcher for subIcon test tags
+    private fun hasTestTagPrefix(prefix: String): SemanticsMatcher {
+        return hasTestTag(ComplicationTagMatcher(prefix).toString())
+    }
+
+    private fun ComplicationTagMatcher(prefix: String): (String) -> Boolean = {
+        it.startsWith(prefix)
+    }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixToolboxFloatingButton.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixToolboxFloatingButton.kt
@@ -35,63 +35,55 @@ fun QuickFixToolboxFloatingButton(
     onIconClick: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var expanded by remember { mutableStateOf(false) }
+  var expanded by remember { mutableStateOf(false) }
 
-    BoxWithConstraints {
-        val screenHeight = maxHeight.value
+  BoxWithConstraints {
+    val screenHeight = maxHeight.value
 
-        Column(
-            modifier = modifier,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            AnimatedVisibility(
-                visible = expanded,
-                enter = fadeIn() + slideInVertically(initialOffsetY = { it }),
-                exit = fadeOut() + slideOutVertically(targetOffsetY = { it })
-            ) {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy((screenHeight * 0.01).dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    iconList.forEachIndexed { index, icon ->
-                        Surface(
-                            shape = RoundedCornerShape(20.dp),
-                            modifier = Modifier
-                                .size((screenHeight * 0.06).dp)
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+      AnimatedVisibility(
+          visible = expanded,
+          enter = fadeIn() + slideInVertically(initialOffsetY = { it }),
+          exit = fadeOut() + slideOutVertically(targetOffsetY = { it })) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy((screenHeight * 0.01).dp),
+                horizontalAlignment = Alignment.CenterHorizontally) {
+                  iconList.forEachIndexed { index, icon ->
+                    Surface(
+                        shape = RoundedCornerShape(20.dp),
+                        modifier =
+                            Modifier.size((screenHeight * 0.06).dp)
                                 .clickable { onIconClick(index) }
                                 .testTag("subIcon$index"),
-                            color = colorScheme.surface,
-                            shadowElevation = 5.dp
-                        ) {
-                            Icon(
-                                imageVector = icon,
-                                contentDescription = "Sub Icon $index",
-                                modifier = Modifier.padding((screenHeight * 0.012).dp),
-                                tint = colorScheme.primary
-                            )
+                        color = colorScheme.surface,
+                        shadowElevation = 5.dp) {
+                          Icon(
+                              imageVector = icon,
+                              contentDescription = "Sub Icon $index",
+                              modifier = Modifier.padding((screenHeight * 0.012).dp),
+                              tint = colorScheme.primary)
                         }
-                    }
+                  }
                 }
-            }
+          }
 
-            Spacer(modifier = Modifier.height((screenHeight * 0.01).dp))
+      Spacer(modifier = Modifier.height((screenHeight * 0.01).dp))
 
-            Surface(
-                shape = RoundedCornerShape(20.dp),
-                modifier = Modifier
-                    .size((screenHeight * 0.07).dp)
-                    .clickable { expanded = !expanded }
-                    .testTag("mainIcon"),
-                color = if (!expanded) colorScheme.surface else colorScheme.primary,
-                shadowElevation = 5.dp
-            ) {
-                Icon(
-                    imageVector = mainIcon,
-                    contentDescription = "Main Icon",
-                    modifier = Modifier.padding((screenHeight * 0.01).dp),
-                    tint = if (!expanded) colorScheme.primary else colorScheme.surface,
-                )
-            }
-        }
+      Surface(
+          shape = RoundedCornerShape(20.dp),
+          modifier =
+              Modifier.size((screenHeight * 0.07).dp)
+                  .clickable { expanded = !expanded }
+                  .testTag("mainIcon"),
+          color = if (!expanded) colorScheme.surface else colorScheme.primary,
+          shadowElevation = 5.dp) {
+            Icon(
+                imageVector = mainIcon,
+                contentDescription = "Main Icon",
+                modifier = Modifier.padding((screenHeight * 0.01).dp),
+                tint = if (!expanded) colorScheme.primary else colorScheme.surface,
+            )
+          }
     }
+  }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixToolboxFloatingButton.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixToolboxFloatingButton.kt
@@ -1,0 +1,97 @@
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Work
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun QuickFixToolboxFloatingButton(
+    mainIcon: ImageVector = Icons.Default.Work,
+    iconList: List<ImageVector>,
+    onIconClick: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    BoxWithConstraints {
+        val screenHeight = maxHeight.value
+
+        Column(
+            modifier = modifier,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            AnimatedVisibility(
+                visible = expanded,
+                enter = fadeIn() + slideInVertically(initialOffsetY = { it }),
+                exit = fadeOut() + slideOutVertically(targetOffsetY = { it })
+            ) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy((screenHeight * 0.01).dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    iconList.forEachIndexed { index, icon ->
+                        Surface(
+                            shape = RoundedCornerShape(20.dp),
+                            modifier = Modifier
+                                .size((screenHeight * 0.06).dp)
+                                .clickable { onIconClick(index) }
+                                .testTag("subIcon$index"),
+                            color = colorScheme.surface,
+                            shadowElevation = 5.dp
+                        ) {
+                            Icon(
+                                imageVector = icon,
+                                contentDescription = "Sub Icon $index",
+                                modifier = Modifier.padding((screenHeight * 0.012).dp),
+                                tint = colorScheme.primary
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height((screenHeight * 0.01).dp))
+
+            Surface(
+                shape = RoundedCornerShape(20.dp),
+                modifier = Modifier
+                    .size((screenHeight * 0.07).dp)
+                    .clickable { expanded = !expanded }
+                    .testTag("mainIcon"),
+                color = if (!expanded) colorScheme.surface else colorScheme.primary,
+                shadowElevation = 5.dp
+            ) {
+                Icon(
+                    imageVector = mainIcon,
+                    contentDescription = "Main Icon",
+                    modifier = Modifier.padding((screenHeight * 0.01).dp),
+                    tint = if (!expanded) colorScheme.primary else colorScheme.surface,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/home/HomeScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/home/HomeScreen.kt
@@ -74,183 +74,142 @@ fun HomeScreen(
     workerViewModel: ProfileViewModel,
     quickFixViewModel: QuickFixViewModel
 ) {
-    val focusManager = LocalFocusManager.current
-    // Sample data for services and quick fixes
-    val services =
-        listOf(
-            Service("Painter", R.drawable.painter),
-            Service("Gardener", R.drawable.gardener),
-            Service("Electrician", R.drawable.electrician)
-        )
+  val focusManager = LocalFocusManager.current
+  // Sample data for services and quick fixes
+  val services =
+      listOf(
+          Service("Painter", R.drawable.painter),
+          Service("Gardener", R.drawable.gardener),
+          Service("Electrician", R.drawable.electrician))
 
-    var quickFixes by remember { mutableStateOf(emptyList<QuickFix>()) }
-    var mode by remember { mutableStateOf("") }
-    var uid by remember { mutableStateOf("") }
-    LaunchedEffect(Unit) {
-        mode = loadAppMode(preferencesViewModel)
-        uid = loadUserId(preferencesViewModel)
-        userViewModel.fetchUserProfile(uid) { profile ->
-            profile?.quickFixes?.forEach { quickFix ->
-                quickFixViewModel.fetchQuickFix(quickFix) {
-                    if (it != null) {
-                        quickFixes = quickFixes + it
-                    }
-                }
-            }
+  var quickFixes by remember { mutableStateOf(emptyList<QuickFix>()) }
+  var mode by remember { mutableStateOf("") }
+  var uid by remember { mutableStateOf("") }
+  LaunchedEffect(Unit) {
+    mode = loadAppMode(preferencesViewModel)
+    uid = loadUserId(preferencesViewModel)
+    userViewModel.fetchUserProfile(uid) { profile ->
+      profile?.quickFixes?.forEach { quickFix ->
+        quickFixViewModel.fetchQuickFix(quickFix) {
+          if (it != null) {
+            quickFixes = quickFixes + it
+          }
         }
+      }
     }
+  }
 
-
-    Scaffold(
-        modifier =
-        Modifier
-            .pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
-            .testTag("HomeScreen"),
-        containerColor = colorScheme.background,
-        floatingActionButton = {
-            QuickFixToolboxFloatingButton(
-                iconList = listOf(
-                    Icons.Default.Map,
-                    Icons.Default.AutoAwesome,
-                    Icons.Default.Create
-                ),
-                onIconClick = {},
-                modifier = Modifier
-                    .padding(16.dp)
-                    .testTag("ToolboxFloatingButton")
-            )
-        },
-        topBar = {
-            TopAppBar(
-                title = {
-                    Column {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(0.dp),
-                            horizontalArrangement = Arrangement.Start,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Image(
-                                painter = painterResource(id = R.drawable.home_screen_headline),
-                                contentDescription = "home_title",
-                                modifier = Modifier.size(200.dp)
-                            )
-                        }
+  Scaffold(
+      modifier =
+          Modifier.pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
+              .testTag("HomeScreen"),
+      containerColor = colorScheme.background,
+      floatingActionButton = {
+        QuickFixToolboxFloatingButton(
+            iconList = listOf(Icons.Default.Map, Icons.Default.AutoAwesome, Icons.Default.Create),
+            onIconClick = {},
+            modifier = Modifier.padding(16.dp).testTag("ToolboxFloatingButton"))
+      },
+      topBar = {
+        TopAppBar(
+            title = {
+              Column {
+                Row(
+                    modifier = Modifier.fillMaxSize().padding(0.dp),
+                    horizontalArrangement = Arrangement.Start,
+                    verticalAlignment = Alignment.CenterVertically) {
+                      Image(
+                          painter = painterResource(id = R.drawable.home_screen_headline),
+                          contentDescription = "home_title",
+                          modifier = Modifier.size(200.dp))
                     }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
-                navigationIcon = {},
-                actions = {
-                    IconButton(
-                        onClick = { navigationActions.navigateTo(UserScreen.MESSAGES) },
-                        Modifier.testTag("MessagesButton")
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Email,
-                            contentDescription = "Messages",
-                            tint = colorScheme.background
-                        )
-                    }
-                })
-        },
-        content = { padding ->
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-            ) {
-                Column(
-                    modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(vertical = 8.dp)
-                        .testTag("homeContent"),
-                    verticalArrangement = Arrangement.Top,
-                    horizontalAlignment = Alignment.Start
+              }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
+            navigationIcon = {},
+            actions = {
+              IconButton(
+                  onClick = { navigationActions.navigateTo(UserScreen.MESSAGES) },
+                  Modifier.testTag("MessagesButton")) {
+                    Icon(
+                        imageVector = Icons.Outlined.Email,
+                        contentDescription = "Messages",
+                        tint = colorScheme.background)
+                  }
+            })
+      },
+      content = { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+          Column(
+              modifier = Modifier.fillMaxSize().padding(vertical = 8.dp).testTag("homeContent"),
+              verticalArrangement = Arrangement.Top,
+              horizontalAlignment = Alignment.Start) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Spacer(modifier = Modifier.width(10.dp))
-                        Log.d("QuickFixTextFieldCustomHomeScreen", "DISPLAYED")
-                        QuickFixTextFieldCustom(
-                            modifier = Modifier.semantics { testTag = "searchBar" },
-                            showLeadingIcon = { true },
-                            showTrailingIcon = { true },
-                            leadingIcon = Icons.Outlined.Search,
-                            trailingIcon = { Icons.Default.Clear },
-                            descriptionLeadIcon = "Search",
-                            descriptionTrailIcon = "Clear",
-                            placeHolderText = "Find your perfect fix with QuickFix",
-                            shape = CircleShape,
-                            textStyle = poppinsTypography.bodyMedium,
-                            textColor = colorScheme.onBackground,
-                            placeHolderColor = colorScheme.onBackground,
-                            leadIconColor = colorScheme.onBackground,
-                            trailIconColor = colorScheme.onBackground,
-                            widthField = 330.dp,
-                            heightField = 40.dp,
-                            onValueChange = {},
-                            value = "",
-                            debug = "homescreen"
-                        )
+                  Spacer(modifier = Modifier.width(10.dp))
+                  Log.d("QuickFixTextFieldCustomHomeScreen", "DISPLAYED")
+                  QuickFixTextFieldCustom(
+                      modifier = Modifier.semantics { testTag = "searchBar" },
+                      showLeadingIcon = { true },
+                      showTrailingIcon = { true },
+                      leadingIcon = Icons.Outlined.Search,
+                      trailingIcon = { Icons.Default.Clear },
+                      descriptionLeadIcon = "Search",
+                      descriptionTrailIcon = "Clear",
+                      placeHolderText = "Find your perfect fix with QuickFix",
+                      shape = CircleShape,
+                      textStyle = poppinsTypography.bodyMedium,
+                      textColor = colorScheme.onBackground,
+                      placeHolderColor = colorScheme.onBackground,
+                      leadIconColor = colorScheme.onBackground,
+                      trailIconColor = colorScheme.onBackground,
+                      widthField = 330.dp,
+                      heightField = 40.dp,
+                      onValueChange = {},
+                      value = "",
+                      debug = "homescreen")
 
-                        Spacer(modifier = Modifier.width(20.dp))
+                  Spacer(modifier = Modifier.width(20.dp))
 
-                        IconButton(
-                            onClick = { navigationActions.navigateTo(UserScreen.MESSAGES) },
-                            modifier =
-                            Modifier
-                                .size(40.dp)
-                                .clip(CircleShape)
-                                .background(colorScheme.surface)
-                                .padding(8.dp)
-                                .testTag(C.Tag.notification)
-                        ) {
-                            Icon(
-                                painter = painterResource(id = R.drawable.bell),
-                                contentDescription = "notifications",
-                                tint = colorScheme.primary
-                            )
-                        }
-                    }
-
-                    Text(
-                        text = "Popular services",
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 8.dp)
-                    )
-
-                    PopularServicesRow(
-                        services = services,
-                        modifier = Modifier.testTag("PopularServicesRow"),
-                        onServiceClick = { /* Handle Service Click */ })
-
-                    Spacer(modifier = Modifier.weight(0.09f))
-
-                    Box(
-                        modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .zIndex(2f)
-                            .weight(1.5f)
-                    ) {
-                        QuickFixesWidget(
-                            status = "Upcoming",
-                            quickFixList = quickFixes,
-                            onShowAllClick = { /* Handle Show All Click */ },
-                            onItemClick = { /* Handle QuickFix Item Click */ },
-                            modifier = Modifier.testTag("UpcomingQuickFixes"),
-                            workerViewModel = workerViewModel,
-                        )
-                    }
+                  IconButton(
+                      onClick = { navigationActions.navigateTo(UserScreen.MESSAGES) },
+                      modifier =
+                          Modifier.size(40.dp)
+                              .clip(CircleShape)
+                              .background(colorScheme.surface)
+                              .padding(8.dp)
+                              .testTag(C.Tag.notification)) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.bell),
+                            contentDescription = "notifications",
+                            tint = colorScheme.primary)
+                      }
                 }
-            }
-        })
 
+                Text(
+                    text = "Popular services",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp))
 
+                PopularServicesRow(
+                    services = services,
+                    modifier = Modifier.testTag("PopularServicesRow"),
+                    onServiceClick = { /* Handle Service Click */})
+
+                Spacer(modifier = Modifier.weight(0.09f))
+
+                Box(modifier = Modifier.fillMaxWidth().zIndex(2f).weight(1.5f)) {
+                  QuickFixesWidget(
+                      status = "Upcoming",
+                      quickFixList = quickFixes,
+                      onShowAllClick = { /* Handle Show All Click */},
+                      onItemClick = { /* Handle QuickFix Item Click */},
+                      modifier = Modifier.testTag("UpcomingQuickFixes"),
+                      workerViewModel = workerViewModel,
+                  )
+                }
+              }
+        }
+      })
 }
-

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/home/HomeScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.arygm.quickfix.ui.uiMode.appContentUI.userModeUI.home
 
+import QuickFixToolboxFloatingButton
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -16,7 +17,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.Map
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -44,6 +48,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.arygm.quickfix.R
 import com.arygm.quickfix.model.offline.small.PreferencesViewModel
 import com.arygm.quickfix.model.profile.ProfileViewModel
@@ -69,148 +74,183 @@ fun HomeScreen(
     workerViewModel: ProfileViewModel,
     quickFixViewModel: QuickFixViewModel
 ) {
-  val focusManager = LocalFocusManager.current
-  // Sample data for services and quick fixes
-  val services =
-      listOf(
-          Service("Painter", R.drawable.painter),
-          Service("Gardener", R.drawable.gardener),
-          Service("Electrician", R.drawable.electrician))
+    val focusManager = LocalFocusManager.current
+    // Sample data for services and quick fixes
+    val services =
+        listOf(
+            Service("Painter", R.drawable.painter),
+            Service("Gardener", R.drawable.gardener),
+            Service("Electrician", R.drawable.electrician)
+        )
 
-  var quickFixes by remember { mutableStateOf(emptyList<QuickFix>()) }
-  var mode by remember { mutableStateOf("") }
-  var uid by remember { mutableStateOf("") }
-  LaunchedEffect(Unit) {
-    mode = loadAppMode(preferencesViewModel)
-    uid = loadUserId(preferencesViewModel)
-    userViewModel.fetchUserProfile(uid) { profile ->
-      profile?.quickFixes?.forEach { quickFix ->
-        quickFixViewModel.fetchQuickFix(quickFix) {
-          if (it != null) {
-            quickFixes = quickFixes + it
-          }
-        }
-      }
-    }
-  }
-
-  Scaffold(
-      modifier =
-          Modifier.pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
-              .testTag("HomeScreen"),
-      containerColor = colorScheme.background,
-      topBar = {
-        TopAppBar(
-            title = {
-              Column {
-                Row(
-                    modifier = Modifier.fillMaxSize().padding(0.dp),
-                    horizontalArrangement = Arrangement.Start,
-                    verticalAlignment = Alignment.CenterVertically) {
-                      Image(
-                          painter = painterResource(id = R.drawable.home_screen_headline),
-                          contentDescription = "home_title",
-                          modifier = Modifier.size(200.dp))
+    var quickFixes by remember { mutableStateOf(emptyList<QuickFix>()) }
+    var mode by remember { mutableStateOf("") }
+    var uid by remember { mutableStateOf("") }
+    LaunchedEffect(Unit) {
+        mode = loadAppMode(preferencesViewModel)
+        uid = loadUserId(preferencesViewModel)
+        userViewModel.fetchUserProfile(uid) { profile ->
+            profile?.quickFixes?.forEach { quickFix ->
+                quickFixViewModel.fetchQuickFix(quickFix) {
+                    if (it != null) {
+                        quickFixes = quickFixes + it
                     }
-              }
-            },
-            colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
-            navigationIcon = {},
-            actions = {
-              IconButton(
-                  onClick = { navigationActions.navigateTo(UserScreen.MESSAGES) },
-                  Modifier.testTag("MessagesButton")) {
-                    Icon(
-                        imageVector = Icons.Outlined.Email,
-                        contentDescription = "Messages",
-                        tint = colorScheme.background)
-                  }
-            })
-      },
-      content = { padding ->
-        Column(
-            modifier =
-                Modifier.fillMaxSize()
-                    .padding(padding)
-                    .padding(vertical = 8.dp)
-                    .testTag("homeContent"),
-            verticalArrangement = Arrangement.Top,
-            horizontalAlignment = Alignment.Start) {
-              // Keep the Row unchanged
-              Row(
-                  modifier = Modifier.fillMaxWidth(),
-              ) {
-                Spacer(modifier = Modifier.width(10.dp))
-                Log.d("QuickFixTextFieldCustomHomeScreen", "DISPLAYED")
-                QuickFixTextFieldCustom(
-                    modifier = Modifier.semantics { testTag = "searchBar" },
-                    showLeadingIcon = { true },
-                    showTrailingIcon = { true },
-                    leadingIcon = Icons.Outlined.Search,
-                    trailingIcon = { Icons.Default.Clear },
-                    descriptionLeadIcon = "Search",
-                    descriptionTrailIcon = "Clear",
-                    placeHolderText = "Find your perfect fix with QuickFix",
-                    shape = CircleShape,
-                    textStyle = poppinsTypography.bodyMedium,
-                    textColor = colorScheme.onBackground,
-                    placeHolderColor = colorScheme.onBackground,
-                    leadIconColor = colorScheme.onBackground,
-                    trailIconColor = colorScheme.onBackground,
-                    widthField = 330.dp, // unchanged width
-                    heightField = 40.dp, // unchanged height
-                    onValueChange = {},
-                    value = "",
-                    debug = "homescreen")
-
-                Spacer(modifier = Modifier.width(20.dp))
-
-                IconButton(
-                    onClick = { navigationActions.navigateTo(UserScreen.MESSAGES) },
-                    modifier =
-                        Modifier.size(40.dp)
-                            .clip(CircleShape)
-                            .background(colorScheme.surface)
-                            .padding(8.dp)
-                            .testTag(C.Tag.notification)) {
-                      Icon(
-                          painter = painterResource(id = R.drawable.bell),
-                          contentDescription = "notifications",
-                          tint = colorScheme.primary)
-                    }
-              }
-
-              // Popular Services Row
-              Text(
-                  text = "Popular services",
-                  style = MaterialTheme.typography.titleMedium,
-                  modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp))
-
-              // Adjust the PopularServicesRow to take flexible height and width
-
-              PopularServicesRow(
-                  services = services,
-                  modifier = Modifier.testTag("PopularServicesRow"),
-                  onServiceClick = { /* Handle Service Click */})
-
-              // Spacer with flexible height using weight
-              Spacer(modifier = Modifier.weight(0.09f))
-
-              // Upcoming QuickFixes with flexible height
-              Box(
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .weight(1.5f) // Flexible space, larger than the PopularServicesRow
-                  ) {
-                    QuickFixesWidget(
-                        status = "Upcoming",
-                        quickFixList = quickFixes,
-                        onShowAllClick = { /* Handle Show All Click */},
-                        onItemClick = { /* Handle QuickFix Item Click */},
-                        modifier = Modifier.testTag("UpcomingQuickFixes"),
-                        workerViewModel = workerViewModel,
-                    )
-                  }
+                }
             }
-      })
+        }
+    }
+
+
+    Scaffold(
+        modifier =
+        Modifier
+            .pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) }
+            .testTag("HomeScreen"),
+        containerColor = colorScheme.background,
+        floatingActionButton = {
+            QuickFixToolboxFloatingButton(
+                iconList = listOf(
+                    Icons.Default.Map,
+                    Icons.Default.AutoAwesome,
+                    Icons.Default.Create
+                ),
+                onIconClick = {},
+                modifier = Modifier
+                    .padding(16.dp)
+                    .testTag("ToolboxFloatingButton")
+            )
+        },
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(0.dp),
+                            horizontalArrangement = Arrangement.Start,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Image(
+                                painter = painterResource(id = R.drawable.home_screen_headline),
+                                contentDescription = "home_title",
+                                modifier = Modifier.size(200.dp)
+                            )
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.background),
+                navigationIcon = {},
+                actions = {
+                    IconButton(
+                        onClick = { navigationActions.navigateTo(UserScreen.MESSAGES) },
+                        Modifier.testTag("MessagesButton")
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Email,
+                            contentDescription = "Messages",
+                            tint = colorScheme.background
+                        )
+                    }
+                })
+        },
+        content = { padding ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+            ) {
+                Column(
+                    modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(vertical = 8.dp)
+                        .testTag("homeContent"),
+                    verticalArrangement = Arrangement.Top,
+                    horizontalAlignment = Alignment.Start
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Spacer(modifier = Modifier.width(10.dp))
+                        Log.d("QuickFixTextFieldCustomHomeScreen", "DISPLAYED")
+                        QuickFixTextFieldCustom(
+                            modifier = Modifier.semantics { testTag = "searchBar" },
+                            showLeadingIcon = { true },
+                            showTrailingIcon = { true },
+                            leadingIcon = Icons.Outlined.Search,
+                            trailingIcon = { Icons.Default.Clear },
+                            descriptionLeadIcon = "Search",
+                            descriptionTrailIcon = "Clear",
+                            placeHolderText = "Find your perfect fix with QuickFix",
+                            shape = CircleShape,
+                            textStyle = poppinsTypography.bodyMedium,
+                            textColor = colorScheme.onBackground,
+                            placeHolderColor = colorScheme.onBackground,
+                            leadIconColor = colorScheme.onBackground,
+                            trailIconColor = colorScheme.onBackground,
+                            widthField = 330.dp,
+                            heightField = 40.dp,
+                            onValueChange = {},
+                            value = "",
+                            debug = "homescreen"
+                        )
+
+                        Spacer(modifier = Modifier.width(20.dp))
+
+                        IconButton(
+                            onClick = { navigationActions.navigateTo(UserScreen.MESSAGES) },
+                            modifier =
+                            Modifier
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(colorScheme.surface)
+                                .padding(8.dp)
+                                .testTag(C.Tag.notification)
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.bell),
+                                contentDescription = "notifications",
+                                tint = colorScheme.primary
+                            )
+                        }
+                    }
+
+                    Text(
+                        text = "Popular services",
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+
+                    PopularServicesRow(
+                        services = services,
+                        modifier = Modifier.testTag("PopularServicesRow"),
+                        onServiceClick = { /* Handle Service Click */ })
+
+                    Spacer(modifier = Modifier.weight(0.09f))
+
+                    Box(
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .zIndex(2f)
+                            .weight(1.5f)
+                    ) {
+                        QuickFixesWidget(
+                            status = "Upcoming",
+                            quickFixList = quickFixes,
+                            onShowAllClick = { /* Handle Show All Click */ },
+                            onItemClick = { /* Handle QuickFix Item Click */ },
+                            modifier = Modifier.testTag("UpcomingQuickFixes"),
+                            workerViewModel = workerViewModel,
+                        )
+                    }
+                }
+            }
+        })
+
+
 }
+


### PR DESCRIPTION
The first step into adding a brand new feature, a _**toolbox**_ that will allow the user to seamlessly navigate to a:
- Map utility to visualize the workers around
- AI ChatBot to aid in navigating the app
- Projects (Not sure to be implemented yet)

_**Commit History:**_
`task: implement floating toolbox button`
- [x] Add `QuickFixToolboxFloatingButton` element

`test: add tests for floating button`
- [x] Adequately test the floating button

`task: include toolbox in homescreen`
- [x] Include the new element in the `HomeScreen`

`test: write tests for new functionality and ktfmt`
- [x] Adequately test the addition of the floating button on the screen