### PR TITLE
Worker Announcements View Implementation

### DIFF
--- a/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixLocationFilterBottomSheetTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/elements/QuickFixLocationFilterBottomSheetTest.kt
@@ -46,7 +46,7 @@ class QuickFixLocationFilterBottomSheetTest {
       QuickFixTheme {
         QuickFixLocationFilterBottomSheet(
             showModalBottomSheet = true,
-            userProfile = userProfile,
+            profile = userProfile,
             phoneLocation = phoneLocation,
             onApplyClick = onApplyClick,
             onDismissRequest = onDismissRequest,
@@ -64,7 +64,7 @@ class QuickFixLocationFilterBottomSheetTest {
       QuickFixTheme {
         QuickFixLocationFilterBottomSheet(
             showModalBottomSheet = false,
-            userProfile = userProfile,
+            profile = userProfile,
             phoneLocation = phoneLocation,
             onApplyClick = onApplyClick,
             onDismissRequest = onDismissRequest,
@@ -82,7 +82,7 @@ class QuickFixLocationFilterBottomSheetTest {
       QuickFixTheme {
         QuickFixLocationFilterBottomSheet(
             showModalBottomSheet = true,
-            userProfile = userProfile,
+            profile = userProfile,
             phoneLocation = phoneLocation,
             onApplyClick = onApplyClick,
             onDismissRequest = onDismissRequest,
@@ -113,7 +113,7 @@ class QuickFixLocationFilterBottomSheetTest {
       QuickFixTheme {
         QuickFixLocationFilterBottomSheet(
             showModalBottomSheet = true,
-            userProfile = userProfile,
+            profile = userProfile,
             phoneLocation = phoneLocation,
             onApplyClick = onApplyClick,
             onDismissRequest = onDismissRequest,
@@ -147,7 +147,7 @@ class QuickFixLocationFilterBottomSheetTest {
       QuickFixTheme {
         QuickFixLocationFilterBottomSheet(
             showModalBottomSheet = true,
-            userProfile = userProfile,
+            profile = userProfile,
             phoneLocation = phoneLocation,
             onApplyClick = { loc, r ->
               appliedLocation = loc
@@ -183,7 +183,7 @@ class QuickFixLocationFilterBottomSheetTest {
       QuickFixTheme {
         QuickFixLocationFilterBottomSheet(
             showModalBottomSheet = true,
-            userProfile = userProfile,
+            profile = userProfile,
             phoneLocation = phoneLocation,
             onApplyClick = onApplyClick,
             onDismissRequest = onDismissRequest,
@@ -206,7 +206,7 @@ class QuickFixLocationFilterBottomSheetTest {
       QuickFixTheme {
         QuickFixLocationFilterBottomSheet(
             showModalBottomSheet = true,
-            userProfile = userProfile,
+            profile = userProfile,
             phoneLocation = phoneLocation,
             onApplyClick = onApplyClick,
             onDismissRequest = { dismissCalled = true },
@@ -238,7 +238,7 @@ class QuickFixLocationFilterBottomSheetTest {
       QuickFixTheme {
         QuickFixLocationFilterBottomSheet(
             showModalBottomSheet = true,
-            userProfile = userProfile,
+            profile = userProfile,
             phoneLocation = phoneLocation,
             onApplyClick = onApplyClick,
             onDismissRequest = { dismissCalled = true },

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementCardTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementCardTest.kt
@@ -15,6 +15,7 @@ import com.arygm.quickfix.ui.uiMode.appContentUI.workerMode.announcements.Announ
 import com.google.firebase.Timestamp
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -50,7 +51,9 @@ class AnnouncementCardTest {
   @Test
   fun announcementCard_withImage_andCategory_andAccount() {
     // Mock category found
-    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+    every {
+      runBlocking { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) }
+    } answers
         {
           val onSuccess = arg<(Category?) -> Unit>(1)
           onSuccess(
@@ -125,7 +128,9 @@ class AnnouncementCardTest {
   @Test
   fun announcementCard_noImage_noCategory_noAccount_noLocation() {
     // Mock category returns null
-    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+    every {
+      runBlocking { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) }
+    } answers
         {
           val onSuccess = arg<(Category?) -> Unit>(1)
           onSuccess(null)
@@ -194,7 +199,9 @@ class AnnouncementCardTest {
         }
 
     // category found scenario
-    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+    every {
+      runBlocking { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) }
+    } answers
         {
           val onSuccess = arg<(Category?) -> Unit>(1)
           onSuccess(
@@ -240,7 +247,9 @@ class AnnouncementCardTest {
           onResult(laterAccount)
         }
 
-    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+    every {
+      runBlocking { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) }
+    } answers
         {
           val onSuccess = arg<(Category?) -> Unit>(1)
           onSuccess(
@@ -272,7 +281,9 @@ class AnnouncementCardTest {
   @Test
   fun announcementCard_noCategoryInitially_showsDefaultIcon() {
     // Initially return null category
-    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+    every {
+      runBlocking { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) }
+    } answers
         {
           val onSuccess = arg<(Category?) -> Unit>(1)
           onSuccess(null)
@@ -304,7 +315,9 @@ class AnnouncementCardTest {
 
   @Test
   fun announcementCard_categoryFetchedInitially_showsCategoryIcon() {
-    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+    every {
+      runBlocking { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) }
+    } answers
         {
           val onSuccess = arg<(Category?) -> Unit>(1)
           onSuccess(

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementCardTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementCardTest.kt
@@ -1,0 +1,341 @@
+package com.arygm.quickfix.ui.search
+
+import android.graphics.Bitmap
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arygm.quickfix.model.account.Account
+import com.arygm.quickfix.model.account.AccountViewModel
+import com.arygm.quickfix.model.category.Category
+import com.arygm.quickfix.model.category.CategoryViewModel
+import com.arygm.quickfix.model.locations.Location
+import com.arygm.quickfix.model.search.Announcement
+import com.arygm.quickfix.ui.theme.QuickFixTheme
+import com.arygm.quickfix.ui.uiMode.appContentUI.workerMode.announcements.AnnouncementCard
+import com.google.firebase.Timestamp
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AnnouncementCardTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var categoryViewModel: CategoryViewModel
+  private lateinit var accountViewModel: AccountViewModel
+
+  private val sampleAnnouncement =
+      Announcement(
+          announcementId = "testAnn",
+          userId = "user123",
+          title = "Test Announcement",
+          category = "testSubCat",
+          description = "A test announcement description",
+          location = Location(10.0, 10.0, "Test Location"),
+          availability = emptyList(),
+          quickFixImages = emptyList())
+  private val timestamp = Timestamp.now()
+
+  @Before
+  fun setup() {
+    categoryViewModel = mockk(relaxed = true)
+    accountViewModel = mockk(relaxed = true)
+  }
+
+  @Test
+  fun announcementCard_withImage_andCategory_andAccount() {
+    // Mock category found
+    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+        {
+          val onSuccess = arg<(Category?) -> Unit>(1)
+          onSuccess(
+              Category(
+                  id = "catId",
+                  name = "Mock Category",
+                  description = "A mock category",
+                  subcategories = emptyList()))
+        }
+
+    // Mock account found
+    every { accountViewModel.fetchUserAccount(eq("user123"), any()) } answers
+        {
+          val onResult = arg<(Account?) -> Unit>(1)
+          onResult(
+              Account(
+                  uid = "user123",
+                  firstName = "John",
+                  lastName = "Doe",
+                  email = "john@doe.com",
+                  birthDate = timestamp))
+        }
+
+    val dummyBitmap = Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888)
+
+    var onClickCalled = false
+
+    composeTestRule.setContent {
+      QuickFixTheme {
+        AnnouncementCard(
+            announcement = sampleAnnouncement,
+            announcementImage = dummyBitmap,
+            accountViewModel = accountViewModel,
+            categoryViewModel = categoryViewModel) {
+              onClickCalled = true
+            }
+      }
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Verify image displayed
+    composeTestRule
+        .onNodeWithTag("AnnouncementImage_testAnn", useUnmergedTree = true)
+        .assertExists()
+
+    // Verify title
+    composeTestRule
+        .onNodeWithTag("AnnouncementTitle_testAnn", useUnmergedTree = true)
+        .assertTextEquals("Test Announcement")
+
+    // Verify description
+    composeTestRule
+        .onNodeWithTag("AnnouncementDescription_testAnn", useUnmergedTree = true)
+        .assertTextEquals("A test announcement description")
+
+    // Verify location
+    composeTestRule
+        .onNodeWithTag("AnnouncementLocation_testAnn", useUnmergedTree = true)
+        .assertTextEquals("Test Location")
+
+    // Verify user name
+    composeTestRule
+        .onNodeWithTag("AnnouncementUserName_testAnn", useUnmergedTree = true)
+        .assertTextContains("By John D.")
+
+    // Click card
+    composeTestRule.onNodeWithTag("AnnouncementCard_testAnn", useUnmergedTree = true).performClick()
+    assertTrue(onClickCalled)
+  }
+
+  @Test
+  fun announcementCard_noImage_noCategory_noAccount_noLocation() {
+    // Mock category returns null
+    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+        {
+          val onSuccess = arg<(Category?) -> Unit>(1)
+          onSuccess(null)
+        }
+
+    // Mock account returns null
+    every { accountViewModel.fetchUserAccount(eq("user123"), any()) } answers
+        {
+          val onResult = arg<(Account?) -> Unit>(1)
+          onResult(null)
+        }
+
+    val noLocationAnnouncement = sampleAnnouncement.copy(location = null)
+
+    composeTestRule.setContent {
+      QuickFixTheme {
+        AnnouncementCard(
+            announcement = noLocationAnnouncement,
+            announcementImage = null, // no image
+            accountViewModel = accountViewModel,
+            categoryViewModel = categoryViewModel) {}
+      }
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Verify loader displayed instead of image
+    composeTestRule
+        .onNodeWithTag("AnnouncementImagePlaceholder_testAnn", useUnmergedTree = true)
+        .assertExists()
+    composeTestRule.onNodeWithTag("Loader_testAnn", useUnmergedTree = true).assertExists()
+
+    // Verify title
+    composeTestRule
+        .onNodeWithTag("AnnouncementTitle_testAnn", useUnmergedTree = true)
+        .assertTextEquals("Test Announcement")
+
+    // Description should still be correct
+    composeTestRule
+        .onNodeWithTag("AnnouncementDescription_testAnn", useUnmergedTree = true)
+        .assertTextEquals("A test announcement description")
+
+    // Location now unknown
+    composeTestRule
+        .onNodeWithTag("AnnouncementLocation_testAnn", useUnmergedTree = true)
+        .assertTextEquals("Unknown")
+
+    // By Unknown user
+    composeTestRule
+        .onNodeWithTag("AnnouncementUserName_testAnn", useUnmergedTree = true)
+        .assertTextEquals("By Unknown")
+
+    // Category icon will still appear even with null category, default icon scenario
+    composeTestRule
+        .onNodeWithTag("AnnouncementCategoryIcon_testAnn", useUnmergedTree = true)
+        .assertExists()
+  }
+
+  @Test
+  fun announcementCard_noAccountInitially_showsUnknown() {
+    // Initially return null account
+    every { accountViewModel.fetchUserAccount(eq("user123"), any()) } answers
+        {
+          val onResult = arg<(Account?) -> Unit>(1)
+          onResult(null)
+        }
+
+    // category found scenario
+    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+        {
+          val onSuccess = arg<(Category?) -> Unit>(1)
+          onSuccess(
+              Category(
+                  id = "catId",
+                  name = "Mock Category",
+                  description = "A mock category",
+                  subcategories = emptyList()))
+        }
+
+    composeTestRule.setContent {
+      QuickFixTheme {
+        AnnouncementCard(
+            announcement = sampleAnnouncement,
+            announcementImage = null,
+            accountViewModel = accountViewModel,
+            categoryViewModel = categoryViewModel) {}
+      }
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Verify initially "By Unknown"
+    composeTestRule
+        .onNodeWithTag("AnnouncementUserName_testAnn", useUnmergedTree = true)
+        .assertTextEquals("By Unknown")
+  }
+
+  @Test
+  fun announcementCard_accountFetchedInitially_showsUserName() {
+    // Now return an account right away
+    val laterAccount =
+        Account(
+            uid = "user123",
+            firstName = "Alice",
+            lastName = "Smith",
+            email = "a@b.com",
+            birthDate = timestamp)
+
+    every { accountViewModel.fetchUserAccount(eq("user123"), any()) } answers
+        {
+          val onResult = arg<(Account?) -> Unit>(1)
+          onResult(laterAccount)
+        }
+
+    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+        {
+          val onSuccess = arg<(Category?) -> Unit>(1)
+          onSuccess(
+              Category(
+                  id = "catId",
+                  name = "Mock Category",
+                  description = "A mock category",
+                  subcategories = emptyList()))
+        }
+
+    composeTestRule.setContent {
+      QuickFixTheme {
+        AnnouncementCard(
+            announcement = sampleAnnouncement,
+            announcementImage = null,
+            accountViewModel = accountViewModel,
+            categoryViewModel = categoryViewModel) {}
+      }
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Check that user name is shown right away
+    composeTestRule
+        .onNodeWithTag("AnnouncementUserName_testAnn", useUnmergedTree = true)
+        .assertTextContains("By Alice S.")
+  }
+
+  @Test
+  fun announcementCard_noCategoryInitially_showsDefaultIcon() {
+    // Initially return null category
+    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+        {
+          val onSuccess = arg<(Category?) -> Unit>(1)
+          onSuccess(null)
+        }
+
+    every { accountViewModel.fetchUserAccount(eq("user123"), any()) } answers
+        {
+          val onResult = arg<(Account?) -> Unit>(1)
+          onResult(null)
+        }
+
+    composeTestRule.setContent {
+      QuickFixTheme {
+        AnnouncementCard(
+            announcement = sampleAnnouncement,
+            announcementImage = null,
+            accountViewModel = accountViewModel,
+            categoryViewModel = categoryViewModel) {}
+      }
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Category is null => default category icon
+    composeTestRule
+        .onNodeWithTag("AnnouncementCategoryIcon_testAnn", useUnmergedTree = true)
+        .assertExists()
+  }
+
+  @Test
+  fun announcementCard_categoryFetchedInitially_showsCategoryIcon() {
+    every { categoryViewModel.getCategoryBySubcategoryId(eq("testSubCat"), any()) } answers
+        {
+          val onSuccess = arg<(Category?) -> Unit>(1)
+          onSuccess(
+              Category(
+                  id = "catId",
+                  name = "Later Category",
+                  description = "",
+                  subcategories = emptyList()))
+        }
+
+    every { accountViewModel.fetchUserAccount(eq("user123"), any()) } answers
+        {
+          val onResult = arg<(Account?) -> Unit>(1)
+          onResult(null)
+        }
+
+    composeTestRule.setContent {
+      QuickFixTheme {
+        AnnouncementCard(
+            announcement = sampleAnnouncement,
+            announcementImage = null,
+            accountViewModel = accountViewModel,
+            categoryViewModel = categoryViewModel) {}
+      }
+    }
+
+    composeTestRule.waitForIdle()
+
+    // Check icon exists after category found initially
+    composeTestRule
+        .onNodeWithTag("AnnouncementCategoryIcon_testAnn", useUnmergedTree = true)
+        .assertExists()
+  }
+}

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementDetailTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementDetailTest.kt
@@ -98,7 +98,7 @@ class AnnouncementDetailTest {
         AnnouncementViewModel(
             announcementRepository = mockAnnouncementRepository,
             preferencesRepository = mockPreferencesRepository,
-            userProfileRepository = mockProfileRepository)
+            profileRepository = mockProfileRepository)
 
     // Select the sample announcement
     announcementViewModel.selectAnnouncement(sampleAnnouncement)

--- a/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementsScreenTest.kt
+++ b/app/src/androidTest/java/com/arygm/quickfix/ui/search/AnnouncementsScreenTest.kt
@@ -1,0 +1,353 @@
+package com.arygm.quickfix.ui.search
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.arygm.quickfix.model.account.AccountViewModel
+import com.arygm.quickfix.model.category.CategoryViewModel
+import com.arygm.quickfix.model.locations.Location
+import com.arygm.quickfix.model.offline.small.PreferencesRepository
+import com.arygm.quickfix.model.offline.small.PreferencesViewModel
+import com.arygm.quickfix.model.profile.ProfileRepository
+import com.arygm.quickfix.model.profile.ProfileViewModel
+import com.arygm.quickfix.model.profile.WorkerProfile
+import com.arygm.quickfix.model.search.Announcement
+import com.arygm.quickfix.model.search.AnnouncementRepository
+import com.arygm.quickfix.model.search.AnnouncementViewModel
+import com.arygm.quickfix.ui.navigation.NavigationActions
+import com.arygm.quickfix.ui.uiMode.appContentUI.workerMode.announcements.AnnouncementsScreen
+import com.arygm.quickfix.ui.uiMode.workerMode.navigation.WorkerScreen
+import com.arygm.quickfix.utils.UID_KEY
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+
+class AnnouncementsScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var announcementViewModel: AnnouncementViewModel
+  private lateinit var preferencesViewModel: PreferencesViewModel
+  private lateinit var workerProfileViewModel: ProfileViewModel
+  private lateinit var categoryViewModel: CategoryViewModel
+  private lateinit var accountViewModel: AccountViewModel
+  private lateinit var mockNavigationActions: NavigationActions
+
+  private lateinit var mockAnnouncementRepository: AnnouncementRepository
+  private lateinit var mockPreferencesRepository: PreferencesRepository
+  private lateinit var mockProfileRepository: ProfileRepository
+
+  private val userIdFlow = MutableStateFlow("workerUserId")
+
+  private val sampleAnnouncements =
+      listOf(
+          Announcement(
+              announcementId = "ann1",
+              userId = "user1",
+              title = "Announcement 1",
+              category = "cat1",
+              description = "Desc1",
+              location = Location(10.0, 10.0, "Loc1"),
+              availability = emptyList(),
+              quickFixImages = emptyList()),
+          Announcement(
+              announcementId = "ann2",
+              userId = "user2",
+              title = "Announcement 2",
+              category = "cat2",
+              description = "Desc2",
+              location = Location(20.0, 20.0, "Loc2"),
+              availability = emptyList(),
+              quickFixImages = emptyList()))
+
+  @Before
+  fun setup() {
+    mockAnnouncementRepository = mock(AnnouncementRepository::class.java)
+    mockPreferencesRepository = mock(PreferencesRepository::class.java)
+    mockProfileRepository = mock(ProfileRepository::class.java)
+    categoryViewModel = mockk(relaxed = true)
+    accountViewModel = mockk(relaxed = true)
+    workerProfileViewModel = ProfileViewModel(mockProfileRepository)
+
+    mockNavigationActions = mock(NavigationActions::class.java)
+
+    preferencesViewModel = PreferencesViewModel(mockPreferencesRepository)
+
+    val userIdKey = UID_KEY
+    whenever(mockPreferencesRepository.getPreferenceByKey(userIdKey)).thenReturn(userIdFlow)
+
+    // Mock announcements flow
+    // By default, no announcements are set until we decide to call getAnnouncements or set them
+    // We'll directly manipulate the announcements in AnnouncementViewModel by mocking the
+    // repository calls.
+    doAnswer { invocation ->
+          val onSuccess = invocation.arguments[0] as (List<Announcement>) -> Unit
+          onSuccess(sampleAnnouncements)
+          null
+        }
+        .whenever(mockAnnouncementRepository)
+        .getAnnouncements(any(), any())
+
+    // Mock init call
+    doAnswer { invocation ->
+          val onSuccess = invocation.arguments[0] as () -> Unit
+          onSuccess()
+          null
+        }
+        .whenever(mockAnnouncementRepository)
+        .init(any())
+
+    // Initialize view model
+    announcementViewModel =
+        AnnouncementViewModel(
+            announcementRepository = mockAnnouncementRepository,
+            preferencesRepository = mockPreferencesRepository,
+            profileRepository = mockProfileRepository)
+
+    // Set announcements
+    announcementViewModel.getAnnouncements()
+
+    // Mock fetching worker profile after userId is loaded
+    doAnswer { invocation ->
+          val uid = invocation.arguments[0] as String
+          val onSuccess = invocation.arguments[1] as (Any?) -> Unit
+          // Return a WorkerProfile
+          onSuccess(WorkerProfile(location = Location(30.0, 30.0, "WorkerLoc"), uid = uid))
+          null
+        }
+        .whenever(mockProfileRepository)
+        .getProfileById(anyString(), any(), any())
+  }
+
+  @Test
+  fun announcementsScreen_displaysProperly() {
+    composeTestRule.setContent {
+      AnnouncementsScreen(
+          announcementViewModel = announcementViewModel,
+          preferencesViewModel = preferencesViewModel,
+          workerProfileViewModel = workerProfileViewModel,
+          categoryViewModel = categoryViewModel,
+          accountViewModel = accountViewModel,
+          navigationActions = mockNavigationActions)
+    }
+
+    // Verify base UI elements
+    composeTestRule.onNodeWithTag("announcements_screen").assertExists()
+    composeTestRule.onNodeWithTag("announcements_scaffold").assertExists()
+    composeTestRule.onNodeWithTag("main_column").assertExists()
+    composeTestRule.onNodeWithTag("title_column").assertExists()
+    composeTestRule.onNodeWithTag("announcements_title").assertTextEquals("Announcements for you")
+    composeTestRule
+        .onNodeWithTag("announcements_subtitle")
+        .assertTextEquals("Here are announcements that matches your profile")
+  }
+
+  @Test
+  fun tuneButton_togglesFilterVisibility() {
+    composeTestRule.setContent {
+      AnnouncementsScreen(
+          announcementViewModel = announcementViewModel,
+          preferencesViewModel = preferencesViewModel,
+          workerProfileViewModel = workerProfileViewModel,
+          categoryViewModel = categoryViewModel,
+          accountViewModel = accountViewModel,
+          navigationActions = mockNavigationActions)
+    }
+
+    // Initially, the filter buttons row is there, but the LazyRow with filters is hidden
+    composeTestRule.onNodeWithTag("tuneButton").assertExists()
+    // Since the visibility is false initially, "filter_button_Clear" should not be found
+    composeTestRule.onNodeWithTag("filter_button_Clear").assertDoesNotExist()
+
+    // Click tune button -> show filters
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    // Now the filters should be visible
+    composeTestRule.onNodeWithTag("filter_button_Clear").assertExists()
+
+    // Click tune button again -> hide filters
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    // "filter_button_Clear" should no longer exist
+    composeTestRule.onNodeWithTag("filter_button_Clear").assertDoesNotExist()
+  }
+
+  @Test
+  fun announcements_areDisplayed_andClickable() {
+    composeTestRule.setContent {
+      AnnouncementsScreen(
+          announcementViewModel = announcementViewModel,
+          preferencesViewModel = preferencesViewModel,
+          workerProfileViewModel = workerProfileViewModel,
+          categoryViewModel = categoryViewModel,
+          accountViewModel = accountViewModel,
+          navigationActions = mockNavigationActions)
+    }
+
+    // Check that announcements are displayed
+    composeTestRule.onNodeWithTag("worker_profiles_list").assertExists()
+    composeTestRule.onNodeWithTag("announcement_0").assertExists()
+    composeTestRule.onNodeWithTag("announcement_1").assertExists()
+
+    // Click on an announcement
+    composeTestRule.onNodeWithTag("announcement_0").performClick()
+    verify(mockNavigationActions).navigateTo(eq(WorkerScreen.ANNOUNCEMENT_DETAIL))
+  }
+
+  @Test
+  fun clearFilterButton_resetsFilters() {
+    composeTestRule.setContent {
+      AnnouncementsScreen(
+          announcementViewModel = announcementViewModel,
+          preferencesViewModel = preferencesViewModel,
+          workerProfileViewModel = workerProfileViewModel,
+          categoryViewModel = categoryViewModel,
+          accountViewModel = accountViewModel,
+          navigationActions = mockNavigationActions)
+    }
+
+    // Show filters
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+
+    // Click clear button
+    composeTestRule.onNodeWithTag("filter_button_Clear").performClick()
+
+    // Filters should be reset. Since we had no actual modifications, just ensure no crash
+    // and announcements remain displayed
+    composeTestRule.onNodeWithTag("announcement_0").assertExists()
+    composeTestRule.onNodeWithTag("announcement_1").assertExists()
+  }
+
+  @Test
+  fun applyLocationFilter_withDefaultLocation_showsToast_andFilters() {
+    // Initially locationFilterApplied = false
+    // Show filters
+    composeTestRule.setContent {
+      AnnouncementsScreen(
+          announcementViewModel = announcementViewModel,
+          preferencesViewModel = preferencesViewModel,
+          workerProfileViewModel = workerProfileViewModel,
+          categoryViewModel = categoryViewModel,
+          accountViewModel = accountViewModel,
+          navigationActions = mockNavigationActions)
+    }
+
+    // Show filter buttons
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+
+    // Click location button
+    composeTestRule.onNodeWithTag("filter_button_Location").performClick()
+
+    // The bottom sheet should appear. It's controlled by showLocationBottomSheet
+    // Since we have a WorkerProfile (mocked), the bottom sheet will show location options.
+    // We must select the "Use my Current Location" (option 0)
+    // Perform action: We can't directly interact with QuickFixLocationFilterBottomSheet's internal
+    // elements
+    // since not all test tags might be available. We assume "applyButton" testTag from
+    // QuickFixLocationFilterBottomSheet.
+    // We'll just simulate the scenario by calling onApplyClick indirectly:
+
+    // To ensure line coverage, we need to reflect a scenario:
+    // We'll mock a scenario that location chosen is default (0.0,0.0,"Default") and see if Toast
+    // shows up
+    // Although we can't directly test Toast easily, we can still ensure no crash occurs.
+
+    // Let's simulate tapping apply from the bottom sheet:
+    // For that, we must ensure we have a testTag for "applyButton" inside the bottom sheet (already
+    // added in previous code)
+    composeTestRule.onNodeWithTag("applyButton").assertIsDisplayed().performClick()
+
+    // Now locationFilterApplied = true
+    // We triggered a toast scenario but we can't verify toast in Jetpack Compose tests easily,
+    // just trusting the code runs. Announcements should now be filtered (though we have no real
+    // distance checks)
+    composeTestRule.onNodeWithTag("announcement_0").assertExists()
+  }
+
+  @Test
+  fun applyLocationFilter_withActualLocation_andThenClear() {
+    // Let's simulate a scenario where we first show the bottom sheet and apply a real location
+    // filter
+    // locationFilterApplied should become true after applying
+    composeTestRule.setContent {
+      AnnouncementsScreen(
+          announcementViewModel = announcementViewModel,
+          preferencesViewModel = preferencesViewModel,
+          workerProfileViewModel = workerProfileViewModel,
+          categoryViewModel = categoryViewModel,
+          accountViewModel = accountViewModel,
+          navigationActions = mockNavigationActions)
+    }
+
+    // Show filters
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    // Click location to show bottom sheet
+    composeTestRule.onNodeWithTag("filter_button_Location").performClick()
+
+    // Select a location from the worker profile, index 1 (but we must have test tags from bottom
+    // sheet)
+    // For simplicity, we assume we can select the second option (worker's location)
+    // In your bottomSheet test code, you had a testTag "locationOptionRow1" and "applyButton"
+    composeTestRule.onNodeWithTag("locationOptionRow1").performClick()
+    composeTestRule.onNodeWithTag("applyButton").performClick()
+
+    // locationFilterApplied = true now
+    // Check that announcements still exist
+    composeTestRule.onNodeWithTag("worker_profiles_list").assertExists()
+
+    // Clear filters now by pressing "Clear"
+    composeTestRule.onNodeWithTag("filter_button_Clear").performClick()
+    // locationFilterApplied = false, all announcements should remain visible
+    composeTestRule.onNodeWithTag("announcement_0", useUnmergedTree = true).assertExists()
+    composeTestRule.onNodeWithTag("announcement_1", useUnmergedTree = true).assertExists()
+  }
+
+  @Test
+  fun fetchAnnouncementImagesIsCalledForEachAnnouncement() {
+    verify(mockAnnouncementRepository, times(1)).getAnnouncements(any(), any())
+
+    composeTestRule.setContent {
+      AnnouncementsScreen(
+          announcementViewModel = announcementViewModel,
+          preferencesViewModel = preferencesViewModel,
+          workerProfileViewModel = workerProfileViewModel,
+          categoryViewModel = categoryViewModel,
+          accountViewModel = accountViewModel,
+          navigationActions = mockNavigationActions)
+    }
+
+    // Now just verify that fetchAnnouncementsImagesAsBitmaps is called once per announcement
+    verify(mockAnnouncementRepository, times(sampleAnnouncements.size))
+        .fetchAnnouncementsImagesAsBitmaps(anyString(), any(), any())
+  }
+
+  @Test
+  fun alreadyAppliedLocationFilter_reapplyFiltersAfterNewLocation() {
+    composeTestRule.setContent {
+      AnnouncementsScreen(
+          announcementViewModel = announcementViewModel,
+          preferencesViewModel = preferencesViewModel,
+          workerProfileViewModel = workerProfileViewModel,
+          categoryViewModel = categoryViewModel,
+          accountViewModel = accountViewModel,
+          navigationActions = mockNavigationActions)
+    }
+
+    // Show filters
+    composeTestRule.onNodeWithTag("tuneButton").performClick()
+    // Click location
+    composeTestRule.onNodeWithTag("filter_button_Location").performClick()
+    // Select current location and apply
+    composeTestRule.onNodeWithTag("locationOptionRow0").performClick()
+    composeTestRule.onNodeWithTag("applyButton").performClick()
+
+    composeTestRule.onNodeWithTag("filter_button_Location").performClick()
+    composeTestRule.onNodeWithTag("locationOptionRow1").performClick()
+    composeTestRule.onNodeWithTag("applyButton").performClick()
+
+    composeTestRule.onNodeWithTag("worker_profiles_list").assertExists()
+  }
+}

--- a/app/src/main/java/com/arygm/quickfix/model/search/AnnouncementRepository.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/search/AnnouncementRepository.kt
@@ -15,6 +15,12 @@ interface AnnouncementRepository {
       onFailure: (Exception) -> Unit
   )
 
+  fun getAnnouncementsByCategory(
+      category: String,
+      onSuccess: (List<Announcement>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
   fun announce(announcement: Announcement, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   fun uploadAnnouncementImages(

--- a/app/src/main/java/com/arygm/quickfix/model/search/AnnouncementRepositoryFirestore.kt
+++ b/app/src/main/java/com/arygm/quickfix/model/search/AnnouncementRepositoryFirestore.kt
@@ -78,6 +78,22 @@ class AnnouncementRepositoryFirestore(
         }
   }
 
+  override fun getAnnouncementsByCategory(
+      category: String,
+      onSuccess: (List<Announcement>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .whereEqualTo("category", category) // Query for matching category
+        .get()
+        .addOnSuccessListener { querySnapshot ->
+          val announcements =
+              querySnapshot.documents.mapNotNull { document -> documentToAnnouncement(document) }
+          onSuccess(announcements)
+        }
+        .addOnFailureListener { exception -> onFailure(exception) }
+  }
+
   override fun announce(
       announcement: Announcement,
       onSuccess: () -> Unit,

--- a/app/src/main/java/com/arygm/quickfix/ui/dashboard/AnnouncementsWidget.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/dashboard/AnnouncementsWidget.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme.colorScheme
@@ -37,13 +39,11 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.arygm.quickfix.R
 import com.arygm.quickfix.model.category.Category
 import com.arygm.quickfix.model.category.CategoryViewModel
 import com.arygm.quickfix.model.category.getCategoryIcon
@@ -166,15 +166,15 @@ fun AnnouncementItem(
                       .background(colorScheme.onSurface.copy(alpha = 0.1f))
                       .testTag("AnnouncementImage_${announcement.announcementId}"))
         } else {
-          Image(
-              painter = painterResource(id = R.drawable.placeholder_worker),
-              contentDescription = "Placeholder Image",
-              contentScale = ContentScale.Crop,
+          Box(
               modifier =
                   Modifier.size(40.dp)
                       .clip(RoundedCornerShape(8.dp))
-                      .background(colorScheme.onSurface.copy(alpha = 0.1f))
-                      .testTag("PlaceholderImage_${announcement.announcementId}"))
+                      .background(colorScheme.onSurface.copy(alpha = 0.1f)),
+              contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(
+                    color = colorScheme.primary, modifier = Modifier.testTag("Loader"))
+              }
         }
 
         Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixLocationFilterBottomSheet.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/elements/QuickFixLocationFilterBottomSheet.kt
@@ -41,14 +41,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arygm.quickfix.model.locations.Location
+import com.arygm.quickfix.model.profile.Profile
 import com.arygm.quickfix.model.profile.UserProfile
+import com.arygm.quickfix.model.profile.WorkerProfile
 import com.arygm.quickfix.ui.theme.poppinsTypography
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QuickFixLocationFilterBottomSheet(
     showModalBottomSheet: Boolean,
-    userProfile: UserProfile,
+    profile: Profile,
     phoneLocation: Location,
     selectedLocationIndex: Int? = null,
     onApplyClick: (Location, Int) -> Unit,
@@ -97,7 +99,12 @@ fun QuickFixLocationFilterBottomSheet(
                   Spacer(modifier = Modifier.height(verticalSpacing))
 
                   val locationOptions = mutableListOf("Use my Current Location")
-                  userProfile.locations.forEach { loc -> locationOptions += loc.name }
+                  if (profile is UserProfile) {
+                    profile.locations.forEach { loc -> locationOptions += loc.name }
+                  } else if (profile is WorkerProfile) {
+                    locationOptions += profile.location!!.name
+                  }
+
                   val selectedOption = remember { mutableStateOf<Int?>(selectedLocationIndex) }
 
                   val maxListHeight = heightRatio * 800 * 0.5f
@@ -234,7 +241,12 @@ fun QuickFixLocationFilterBottomSheet(
                           onApplyClick(phoneLocation, range)
                         } else {
                           onApplyClick(
-                              userProfile.locations[selectedOption.value!!.minus(1)], range)
+                              if (profile is UserProfile) {
+                                profile.locations[selectedOption.value!!.minus(1)]
+                              } else if (profile is WorkerProfile) {
+                                profile.location!!
+                              } else Location(0.0, 0.0, "shouldn't happpen"),
+                              range)
                         }
                         onDismissRequest()
                       },

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/AppContentNavGraph.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/AppContentNavGraph.kt
@@ -27,7 +27,7 @@ import com.arygm.quickfix.model.switchModes.ModeViewModel
 import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.uiMode.appContentUI.navigation.AppContentRoute
 import com.arygm.quickfix.ui.uiMode.appContentUI.userModeUI.UserModeNavHost
-import com.arygm.quickfix.ui.uiMode.workerMode.WorkerModeNavGraph
+import com.arygm.quickfix.ui.uiMode.appContentUI.workerMode.WorkerModeNavGraph
 import com.arygm.quickfix.utils.loadAppMode
 
 @Composable
@@ -103,10 +103,12 @@ fun AppContentNavGraph(
         composable(AppContentRoute.WORKER_MODE) {
           WorkerModeNavGraph(
               modeViewModel,
+              workerViewModel,
               isOffline,
               appContentNavigationActions,
               preferencesViewModel,
               accountViewModel,
+              categoryViewModel,
               rootNavigationActions,
               userPreferencesViewModel)
         }

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/UserModeNavGraph.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/UserModeNavGraph.kt
@@ -100,7 +100,7 @@ fun UserModeNavHost(
   val announcementViewModel: AnnouncementViewModel =
       viewModel(
           factory =
-              AnnouncementViewModel.Factory(
+              AnnouncementViewModel.userFactory(
                   announcementRepository = announcementRepository,
                   preferencesRepository = preferencesRepository,
                   userProfileRepository = userProfileRepository))

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/search/SearchWorkerResult.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/search/SearchWorkerResult.kt
@@ -565,7 +565,7 @@ fun SearchWorkerResult(
     userProfile?.let {
       QuickFixLocationFilterBottomSheet(
           showLocationBottomSheet,
-          userProfile = it,
+          profile = it,
           phoneLocation = phoneLocation,
           selectedLocationIndex = selectedLocationIndex,
           onApplyClick = { location, max ->

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/announcements/AnnouncementCard.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/announcements/AnnouncementCard.kt
@@ -1,0 +1,220 @@
+package com.arygm.quickfix.ui.uiMode.appContentUI.workerMode.announcements
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.*
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.arygm.quickfix.model.account.Account
+import com.arygm.quickfix.model.account.AccountViewModel
+import com.arygm.quickfix.model.category.Category
+import com.arygm.quickfix.model.category.CategoryViewModel
+import com.arygm.quickfix.model.category.getCategoryIcon
+import com.arygm.quickfix.model.search.Announcement
+import com.arygm.quickfix.ui.theme.poppinsTypography
+
+@Composable
+fun AnnouncementCard(
+    modifier: Modifier = Modifier,
+    announcement: Announcement,
+    announcementImage: Bitmap?,
+    accountViewModel: AccountViewModel,
+    categoryViewModel: CategoryViewModel,
+    onClick: () -> Unit
+) {
+  var category by remember { mutableStateOf(Category()) }
+  LaunchedEffect(Unit) {
+    categoryViewModel.getCategoryBySubcategoryId(
+        announcement.category,
+        onSuccess = {
+          if (it != null) {
+            category = it
+          }
+        })
+  }
+
+  var account by remember { mutableStateOf<Account?>(null) }
+  LaunchedEffect(announcement.userId) {
+    accountViewModel.fetchUserAccount(announcement.userId) { fetchedAccount: Account? ->
+      account = fetchedAccount
+    }
+  }
+
+  Card(
+      shape = RoundedCornerShape(8.dp),
+      colors = CardDefaults.cardColors(containerColor = colorScheme.surface),
+      elevation = CardDefaults.cardElevation(10.dp),
+      modifier =
+          modifier
+              .fillMaxWidth()
+              .padding(vertical = 10.dp, horizontal = 10.dp)
+              .clickable { onClick() }
+              .testTag("AnnouncementCard_${announcement.announcementId}")) {
+        Row(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(8.dp)
+                    .testTag("AnnouncementCardRow_${announcement.announcementId}"),
+            verticalAlignment = Alignment.CenterVertically) {
+              // Image Placeholder / Actual Image
+              if (announcementImage != null) {
+                Image(
+                    bitmap = announcementImage.asImageBitmap(),
+                    contentDescription = "Announcement Image",
+                    contentScale = ContentScale.FillBounds,
+                    modifier =
+                        Modifier.clip(RoundedCornerShape(8.dp))
+                            .size(100.dp)
+                            .aspectRatio(1f)
+                            .background(colorScheme.onSurface.copy(alpha = 0.1f))
+                            .testTag("AnnouncementImage_${announcement.announcementId}"))
+              } else {
+                Box(
+                    modifier =
+                        Modifier.clip(RoundedCornerShape(8.dp))
+                            .size(100.dp)
+                            .aspectRatio(1f)
+                            .background(colorScheme.onSurface.copy(alpha = 0.1f))
+                            .testTag("AnnouncementImagePlaceholder_${announcement.announcementId}"),
+                    contentAlignment = Alignment.Center) {
+                      CircularProgressIndicator(
+                          color = colorScheme.primary,
+                          modifier = Modifier.testTag("Loader_${announcement.announcementId}"))
+                    }
+              }
+
+              Spacer(
+                  modifier =
+                      Modifier.width(8.dp)
+                          .testTag("SpacerBetweenImageAndContent_${announcement.announcementId}"))
+
+              Column(
+                  modifier =
+                      Modifier.weight(1f)
+                          .testTag("AnnouncementContentColumn_${announcement.announcementId}")) {
+                    // Title Row
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier =
+                            Modifier.testTag(
+                                "AnnouncementTitleRow_${announcement.announcementId}")) {
+                          Text(
+                              text = announcement.title,
+                              style =
+                                  poppinsTypography.bodyMedium.copy(
+                                      fontWeight = FontWeight.Bold, fontSize = 16.sp),
+                              color = colorScheme.onBackground,
+                              maxLines = 1,
+                              overflow = TextOverflow.Ellipsis,
+                              modifier =
+                                  Modifier.testTag(
+                                      "AnnouncementTitle_${announcement.announcementId}"))
+
+                          Spacer(
+                              modifier =
+                                  Modifier.weight(1f)
+                                      .testTag("TitleSpacer_${announcement.announcementId}"))
+
+                          // Category Icon
+                          Icon(
+                              imageVector = getCategoryIcon(category),
+                              contentDescription = "Category Icon",
+                              tint = colorScheme.primary,
+                              modifier =
+                                  Modifier.size(20.dp)
+                                      .testTag(
+                                          "AnnouncementCategoryIcon_${announcement.announcementId}"))
+                        }
+
+                    Spacer(
+                        modifier =
+                            Modifier.height(4.dp)
+                                .testTag("SpacerAfterTitle_${announcement.announcementId}"))
+
+                    // Description
+                    Text(
+                        text = announcement.description,
+                        style = poppinsTypography.bodySmall.copy(fontSize = 12.sp),
+                        fontWeight = FontWeight.Normal,
+                        color = colorScheme.onSurface,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .padding(end = 16.dp)
+                                .testTag("AnnouncementDescription_${announcement.announcementId}"))
+
+                    Spacer(
+                        modifier =
+                            Modifier.height(8.dp)
+                                .testTag("SpacerAfterDescription_${announcement.announcementId}"))
+
+                    // Location Row
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier =
+                            Modifier.testTag(
+                                "AnnouncementLocationRow_${announcement.announcementId}")) {
+                          Icon(
+                              imageVector = Icons.Default.LocationOn,
+                              contentDescription = "Location Icon",
+                              tint = colorScheme.onSurface,
+                              modifier =
+                                  Modifier.size(14.dp)
+                                      .testTag(
+                                          "AnnouncementLocationIcon_${announcement.announcementId}"))
+                          Spacer(
+                              modifier =
+                                  Modifier.width(4.dp)
+                                      .testTag(
+                                          "SpacerInLocationRow_${announcement.announcementId}"))
+                          Text(
+                              text = announcement.location?.name ?: "Unknown",
+                              style = poppinsTypography.bodySmall.copy(fontSize = 9.sp),
+                              color = colorScheme.onSurface,
+                              maxLines = 1,
+                              overflow = TextOverflow.Ellipsis,
+                              modifier =
+                                  Modifier.width(60.dp)
+                                      .testTag(
+                                          "AnnouncementLocation_${announcement.announcementId}"))
+                          Spacer(
+                              modifier =
+                                  Modifier.weight(1f)
+                                      .testTag(
+                                          "SpacerAfterLocation_${announcement.announcementId}"))
+
+                          // Display User Name
+                          Text(
+                              text =
+                                  account?.let {
+                                    "By ${it.firstName} ${it.lastName.firstOrNull()?.uppercase() ?: ""}."
+                                  } ?: "By Unknown",
+                              style = poppinsTypography.bodySmall.copy(fontSize = 9.sp),
+                              color = colorScheme.onSurface,
+                              maxLines = 1,
+                              overflow = TextOverflow.Ellipsis,
+                              modifier =
+                                  Modifier.testTag(
+                                      "AnnouncementUserName_${announcement.announcementId}"))
+                        }
+                  }
+            }
+      }
+}

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/announcements/AnnouncementsScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/announcements/AnnouncementsScreen.kt
@@ -1,20 +1,299 @@
 package com.arygm.quickfix.ui.uiMode.appContentUI.workerMode.announcements
 
+import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.LocationSearching
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.arygm.quickfix.model.account.AccountViewModel
+import com.arygm.quickfix.model.category.CategoryViewModel
+import com.arygm.quickfix.model.offline.small.PreferencesViewModel
+import com.arygm.quickfix.model.profile.ProfileViewModel
+import com.arygm.quickfix.model.profile.WorkerProfile
+import com.arygm.quickfix.model.search.AnnouncementViewModel
+import com.arygm.quickfix.ui.elements.QuickFixButton
+import com.arygm.quickfix.ui.elements.QuickFixLocationFilterBottomSheet
+import com.arygm.quickfix.ui.navigation.NavigationActions
 import com.arygm.quickfix.ui.theme.poppinsTypography
+import com.arygm.quickfix.ui.uiMode.appContentUI.userModeUI.search.SearchFilterButtons
+import com.arygm.quickfix.ui.uiMode.workerMode.navigation.WorkerScreen
+import com.arygm.quickfix.utils.loadUserId
 
 @Composable
-fun AnnouncementsScreen() {
-  Column(
-      modifier = Modifier.fillMaxSize(),
-      verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally) {
-        Text("Announcements Screen", style = poppinsTypography.headlineLarge)
-      }
+fun AnnouncementsScreen(
+    announcementViewModel: AnnouncementViewModel,
+    preferencesViewModel: PreferencesViewModel,
+    workerProfileViewModel: ProfileViewModel,
+    categoryViewModel: CategoryViewModel,
+    accountViewModel: AccountViewModel,
+    navigationActions: NavigationActions
+) {
+  val context = LocalContext.current
+  var workerProfile by remember { mutableStateOf<WorkerProfile?>(null) }
+  var uid by remember { mutableStateOf("Loading...") }
+
+  LaunchedEffect(Unit) {
+    uid = loadUserId(preferencesViewModel)
+    workerProfileViewModel.fetchUserProfile(uid) { profile ->
+      workerProfile = profile as WorkerProfile
+    }
+  }
+
+  val announcements by announcementViewModel.announcements.collectAsState()
+  var filteredAnnouncements by remember { mutableStateOf(announcements) }
+  val imagesForAnnouncements by announcementViewModel.announcementImagesMap.collectAsState()
+
+  var showFilterButtons by remember { mutableStateOf(false) }
+
+  var locationFilterApplied by remember { mutableStateOf(false) }
+  var lastAppliedMaxDist by remember { mutableStateOf(200) }
+  var selectedLocationIndex by remember { mutableStateOf<Int?>(null) }
+
+  var phoneLocation by remember {
+    mutableStateOf(com.arygm.quickfix.model.locations.Location(0.0, 0.0, "Default"))
+  }
+  var baseLocation by remember { mutableStateOf(phoneLocation) }
+  var selectedLocation by remember { mutableStateOf(com.arygm.quickfix.model.locations.Location()) }
+  var maxDistance by remember { mutableStateOf(0) }
+  var showLocationBottomSheet by remember { mutableStateOf(false) }
+
+  fun reapplyFilters() {
+    var updatedAnnouncements = announcements
+
+    if (locationFilterApplied) {
+      updatedAnnouncements =
+          announcementViewModel.filterAnnouncementsByDistance(
+              updatedAnnouncements, selectedLocation, maxDistance)
+    }
+
+    filteredAnnouncements = updatedAnnouncements
+  }
+
+  val listOfButtons =
+      listOf(
+          SearchFilterButtons(
+              onClick = {
+                filteredAnnouncements = announcements
+                locationFilterApplied = false
+                lastAppliedMaxDist = 200
+                selectedLocationIndex = null
+                baseLocation = phoneLocation
+              },
+              text = "Clear",
+              leadingIcon = Icons.Default.Clear,
+              applied = false),
+          SearchFilterButtons(
+              onClick = { showLocationBottomSheet = true },
+              text = "Location",
+              leadingIcon = Icons.Default.LocationSearching,
+              trailingIcon = Icons.Default.KeyboardArrowDown,
+              applied = locationFilterApplied))
+
+  BoxWithConstraints(modifier = Modifier.fillMaxSize().testTag("announcements_screen")) {
+    val screenHeight = maxHeight
+    val screenWidth = maxWidth
+    Scaffold(modifier = Modifier.testTag("announcements_scaffold")) { paddingValues ->
+      Column(
+          modifier =
+              Modifier.fillMaxWidth()
+                  .padding(paddingValues)
+                  .padding(top = screenHeight * 0.02f)
+                  .testTag("main_column"),
+          horizontalAlignment = Alignment.CenterHorizontally) {
+            Column(
+                modifier = Modifier.fillMaxWidth().testTag("title_column"),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Top) {
+                  Text(
+                      text = "Announcements for you",
+                      style = poppinsTypography.labelMedium,
+                      fontSize = 24.sp,
+                      fontWeight = FontWeight.SemiBold,
+                      textAlign = TextAlign.Center,
+                      modifier = Modifier.testTag("announcements_title"))
+                  Text(
+                      text = "Here are announcements that matches your profile",
+                      style = poppinsTypography.labelSmall,
+                      fontWeight = FontWeight.Medium,
+                      fontSize = 12.sp,
+                      color = colorScheme.onSurface,
+                      textAlign = TextAlign.Center,
+                      modifier = Modifier.testTag("announcements_subtitle"))
+                }
+
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(top = screenHeight * 0.02f, bottom = screenHeight * 0.01f)
+                        .padding(horizontal = screenWidth * 0.02f)
+                        .wrapContentHeight()
+                        .testTag("filter_buttons_row"),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+              IconButton(
+                  onClick = { showFilterButtons = !showFilterButtons },
+                  modifier = Modifier.padding(bottom = screenHeight * 0.01f).testTag("tuneButton"),
+                  colors =
+                      IconButtonDefaults.iconButtonColors(
+                          containerColor =
+                              if (showFilterButtons) colorScheme.primary else colorScheme.surface),
+                  content = {
+                    Icon(
+                        imageVector = Icons.Default.Tune,
+                        contentDescription = "Filter",
+                        tint =
+                            if (showFilterButtons) colorScheme.onPrimary
+                            else colorScheme.onBackground,
+                        modifier = Modifier.testTag("tuneIcon"))
+                  })
+
+              Spacer(modifier = Modifier.width(10.dp).testTag("filter_spacer"))
+
+              AnimatedVisibility(
+                  visible = showFilterButtons,
+                  modifier = Modifier.testTag("animated_filter_visibility")) {
+                    LazyRow(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.testTag("lazy_filter_row")) {
+                          items(listOfButtons.size) { index ->
+                            val buttonData = listOfButtons[index]
+                            QuickFixButton(
+                                buttonText = buttonData.text,
+                                onClickAction = buttonData.onClick,
+                                buttonColor =
+                                    if (buttonData.applied) colorScheme.primary
+                                    else colorScheme.surface,
+                                textColor =
+                                    if (buttonData.applied) colorScheme.onPrimary
+                                    else colorScheme.onBackground,
+                                textStyle =
+                                    poppinsTypography.labelSmall.copy(
+                                        fontWeight = FontWeight.Medium),
+                                height = screenHeight * 0.05f,
+                                leadingIcon = buttonData.leadingIcon,
+                                trailingIcon = buttonData.trailingIcon,
+                                leadingIconTint =
+                                    if (buttonData.applied) colorScheme.onPrimary
+                                    else colorScheme.onBackground,
+                                trailingIconTint =
+                                    if (buttonData.applied) colorScheme.onPrimary
+                                    else colorScheme.onBackground,
+                                contentPadding =
+                                    PaddingValues(
+                                        vertical = 0.dp, horizontal = screenWidth * 0.02f),
+                                modifier = Modifier.testTag("filter_button_${buttonData.text}"))
+                            Spacer(
+                                modifier =
+                                    Modifier.width(screenHeight * 0.01f)
+                                        .testTag("filter_button_spacer_$index"))
+                          }
+                        }
+                  }
+            }
+
+            LazyColumn(modifier = Modifier.fillMaxWidth().testTag("worker_profiles_list")) {
+              items(filteredAnnouncements.size) { index ->
+                val announcement = filteredAnnouncements[index]
+
+                LaunchedEffect(Unit) {
+                  announcementViewModel.fetchAnnouncementImagesAsBitmaps(
+                      announcement.announcementId)
+                }
+
+                val pairs = imagesForAnnouncements[announcement.announcementId] ?: emptyList()
+                val bitmapToDisplay = pairs.firstOrNull()?.second
+
+                AnnouncementCard(
+                    modifier = Modifier.testTag("announcement_$index"),
+                    announcement = announcement,
+                    announcementImage = bitmapToDisplay,
+                    accountViewModel = accountViewModel,
+                    categoryViewModel = categoryViewModel) {
+                      announcementViewModel.selectAnnouncement(announcement)
+                      navigationActions.navigateTo(WorkerScreen.ANNOUNCEMENT_DETAIL)
+                    }
+
+                Spacer(
+                    modifier =
+                        Modifier.height(screenHeight * 0.004f)
+                            .testTag("announcement_spacer_$index"))
+              }
+            }
+          }
+    }
+
+    workerProfile?.let {
+      QuickFixLocationFilterBottomSheet(
+          showModalBottomSheet = showLocationBottomSheet,
+          profile = it,
+          phoneLocation = phoneLocation,
+          selectedLocationIndex = selectedLocationIndex,
+          onApplyClick = { location, max ->
+            selectedLocation = location
+            lastAppliedMaxDist = max
+            baseLocation = location
+            maxDistance = max
+
+            if (location == com.arygm.quickfix.model.locations.Location(0.0, 0.0, "Default")) {
+              Toast.makeText(context, "Enable Location In Settings", Toast.LENGTH_SHORT).show()
+            }
+            if (locationFilterApplied) {
+              reapplyFilters()
+            } else {
+              filteredAnnouncements =
+                  announcementViewModel.filterAnnouncementsByDistance(
+                      filteredAnnouncements, location, max)
+            }
+            locationFilterApplied = true
+          },
+          onDismissRequest = { showLocationBottomSheet = false },
+          onClearClick = {
+            baseLocation = phoneLocation
+            lastAppliedMaxDist = 200
+            selectedLocation = com.arygm.quickfix.model.locations.Location()
+            maxDistance = 0
+            locationFilterApplied = false
+            reapplyFilters()
+          },
+          clearEnabled = locationFilterApplied,
+          end = lastAppliedMaxDist)
+    }
+  }
 }

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/navigation/WorkerNavigation.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/workerMode/navigation/WorkerNavigation.kt
@@ -21,6 +21,8 @@ object WorkerScreen {
   const val MESSAGES = "Messages Screen"
   const val PROFILE = "Profile Screen"
   const val ACCOUNT_CONFIGURATION = "Account configuration Screen"
+  const val DISPLAY_IMAGES = "Displayed images Screen"
+  const val ANNOUNCEMENT_DETAIL = "Announcement detail Screen"
 }
 
 object WorkerTopLevelDestinations {


### PR DESCRIPTION
## Overview

This pull request introduces a new "Announcements" view for workers, allowing them to:
- View announcements matching their profiles.
- Filter announcements by location.
- Access detailed information for each announcement.
- Propose a QuickFix to users directly.

## Key Features

### Announcements List
Workers can browse a list of relevant announcements, including titles, descriptions, locations, and user information.

**Screenshot: Announcements List**
![Capture d'écran 2024-12-19 015054](https://github.com/user-attachments/assets/17791ccd-2b3c-4130-bac3-28bc5fa3b38c)


### Announcement Details
Detailed view of each announcement includes:
- Full job description.
- Location details.
- Available dates and times.
- A button to "Propose a QuickFix."

**Screenshot: Announcement Details**
![Capture d'écran 2024-12-19 015111](https://github.com/user-attachments/assets/d22a815b-5e22-416f-83ef-d4959f8b658e)


### Filtering Options
- Apply location-based filters using a bottom sheet modal.
- Clear filters to reset the list.

## Technical Changes
- Added `AnnouncementCard.kt` and `AnnouncementsScreen.kt` composables.
- Enhanced `AnnouncementViewModel` with filtering functionality.
- Integrated with worker navigation flow.

---

This feature enhances the worker experience by making job discovery and interaction easier.