### PR TITLE
Remove the pen icon from the toolbox

### DIFF
--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/home/HomeScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/home/HomeScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.Map
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Search

--- a/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/home/HomeScreen.kt
+++ b/app/src/main/java/com/arygm/quickfix/ui/uiMode/appContentUI/userModeUI/home/HomeScreen.kt
@@ -144,7 +144,7 @@ fun HomeScreen(
         containerColor = colorScheme.background,
         floatingActionButton = {
           QuickFixToolboxFloatingButton(
-              iconList = listOf(Icons.Default.Map, Icons.Default.AutoAwesome, Icons.Default.Create),
+              iconList = listOf(Icons.Default.Map, Icons.Default.AutoAwesome),
               onIconClick = { index ->
                 if (index == 0) {
                   navigationActions.navigateTo(UserScreen.MAP)


### PR DESCRIPTION
Literally the smallest PR I have ever made, there really isn't much to it other than removing the call to the Pen icon in the list of used icons for the toolbox